### PR TITLE
Fix YouTube capitalization on homepage

### DIFF
--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -9,7 +9,7 @@ function Homepage() {
         GPT YouTube Channel Recommender
       </h1>
       <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
-        Input your current Youtube subscriptions, and get a curated new channel recommendation list!
+        Input your current YouTube subscriptions, and get a curated new channel recommendation list!
       </section>
       <HomepageComponent />
       <div className="mt-12">


### PR DESCRIPTION
## Summary
- fix "YouTube" capitalization on homepage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843386df44883209497eed874aed01f