### PR TITLE
[gpt_reco_app] add OpenAI helpers module and refactor components

### DIFF
--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -1,20 +1,9 @@
 import React, { useState } from 'react';
 import OpenAI from 'openai';
 import YouTubeRecommendationList from './YouTubeRecommendationList.jsx';
-import { z } from 'zod';
-import Cookies from 'js-cookie';
 import { zodTextFormat } from 'openai/helpers/zod';
+import { RecommendationsResponse, getOpenAIApiKey } from '../utils/openaiHelpers.js';
 
-// Define the recommendation type schema using zod
-const RecommendationSchema = z.object({
-  channel_name: z.string(),
-  channel_url: z.string(),
-  recommendation_reason: z.string(),
-});
-
-const RecommendationsResponse = z.object({
-  recommendations: z.array(RecommendationSchema),
-});
 
 function YouTubeCriticizer({ subscriptions, recommendations }) {
   const [improvedRecommendations, setImprovedRecommendations] = useState([]);
@@ -24,7 +13,7 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
   // Load API key from cookie on mount
   const [openaiApiKey, setOpenaiApiKey] = React.useState('');
   React.useEffect(() => {
-    const savedKey = Cookies.get('openai_api_key');
+    const savedKey = getOpenAIApiKey();
     if (savedKey) {
       setOpenaiApiKey(savedKey);
     }

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -1,21 +1,9 @@
 import React, { useState } from 'react';
 import OpenAI from 'openai';
-import Cookies from 'js-cookie';
-import { z } from 'zod';
 import { zodTextFormat } from 'openai/helpers/zod';
 import YouTubeRecommendationList from './YouTubeRecommendationList';
 import YouTubeCriticizer from './YouTubeCriticizer';
-
-const RecommendationSchema = z.object({
-  channel_name: z.string(),
-  channel_url: z.string(),
-  recommendation_reason: z.string(),
-});
-
-const RecommendationsResponse = z.object({
-  recommendations: z.array(RecommendationSchema),
-});
-
+import { RecommendationsResponse, getOpenAIApiKey } from '../utils/openaiHelpers.js';
 function YouTubeRecommender() {
   const [inputText, setInputText] = useState('');
   const [recommendations, setRecommendations] = useState(null);
@@ -33,7 +21,7 @@ function YouTubeRecommender() {
   };
 
   const getRecommendations = async () => {
-    const currentApiKey = Cookies.get('openai_api_key');
+    const currentApiKey = getOpenAIApiKey();
     if (!currentApiKey) {
       setRecommendations('API key not found. Please set your OpenAI API key in the homepage.');
       return;

--- a/gpt_reco_app/src/utils/openaiHelpers.js
+++ b/gpt_reco_app/src/utils/openaiHelpers.js
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import Cookies from 'js-cookie';
+
+export const RecommendationSchema = z.object({
+  channel_name: z.string(),
+  channel_url: z.string(),
+  recommendation_reason: z.string(),
+});
+
+export const RecommendationsResponse = z.object({
+  recommendations: z.array(RecommendationSchema),
+});
+
+export function getOpenAIApiKey() {
+  return Cookies.get('openai_api_key');
+}


### PR DESCRIPTION
## Summary
- add `src/utils/openaiHelpers.js` containing shared Zod schemas and an API key helper
- refactor `YouTubeRecommender.jsx` to use the shared helpers
- refactor `YouTubeCriticizer.jsx` similarly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68433e7ce9d48320a4632998ccf2bd21