### PR TITLE
[gpt_reco_app] rename status env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ The repository primarily contains the web application inside the `gpt_reco_app` 
 
 4. Open your browser and navigate to the URL shown in the terminal (usually `http://localhost:5173`).
 
+### Environment Variable
+
+The app checks recommended channel links using a small worker service.
+You can override the default worker URL by setting `VITE_CHANNEL_CHECK_URL`
+before running the dev server or building the project:
+
+```bash
+VITE_CHANNEL_CHECK_URL="https://example.com/?url=" npm run dev
+```
+
+If not set, it defaults to `https://head-checker.louispaulet13.workers.dev/?url=`.
+
 ## Usage
 
 1. On the homepage, enter your OpenAI API key in the provided input field and click "Check API Key" to validate it.

--- a/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
 
+const CHANNEL_CHECK_URL =
+  import.meta.env.VITE_CHANNEL_CHECK_URL ??
+  'https://head-checker.louispaulet13.workers.dev/?url=';
+
 function YouTubeRecommendationList({ recommendations, prompt }) {
   // Remove duplicate recommendations by channel_url
   const uniqueRecommendations = useMemo(() => {
@@ -20,7 +24,7 @@ function YouTubeRecommendationList({ recommendations, prompt }) {
 
   useEffect(() => {
     async function checkUrlStatus(url) {
-      const proxyUrl = 'https://head-checker.louispaulet13.workers.dev/?url=' + (url);
+      const proxyUrl = CHANNEL_CHECK_URL + url;
       try {
         const response = await fetch(proxyUrl, { method: 'GET' });
         const data = await response.json();

--- a/gpt_reco_app/vite.config.js
+++ b/gpt_reco_app/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
@@ -5,6 +7,9 @@ import react from '@vitejs/plugin-react-swc'
 export default defineConfig({
   base: '/',
   plugins: [react()],
+  define: {
+    'import.meta.env.VITE_CHANNEL_CHECK_URL': JSON.stringify(process.env.VITE_CHANNEL_CHECK_URL),
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/setupTests.js',


### PR DESCRIPTION
## Summary
- rename VITE_STATUS_CHECK_URL to VITE_CHANNEL_CHECK_URL for clarity
- update `YouTubeRecommendationList.jsx` and `vite.config.js`
- document the new variable name in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68433e96a9288320843fd39235d5a0c6