### PR TITLE
[gpt_reco_app] simplify layout styles

### DIFF
--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -87,7 +87,7 @@ function HomepageComponent() {
   };
 
   return (
-    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10">
+    <main className="max-w-2xl mx-auto p-8 bg-white rounded-lg shadow-md mt-10">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">Set up your OpenAI API key</h2>
       <input
         type="text"

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -57,7 +57,7 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
   };
 
   return (
-    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md">
+    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-sm">
       <h2 className="text-2xl font-semibold mb-4">Criticizer: Get Better Recommendations</h2>
       <button
         onClick={getImprovedRecommendations}

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -71,7 +71,7 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg">
+    <section className="max-w-2xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-md">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">YouTube Channel Recommender</h2>
       <textarea
         rows={5}

--- a/gpt_reco_app/src/pages/About.jsx
+++ b/gpt_reco_app/src/pages/About.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const About = () => {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-4xl mx-auto">
+      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-sm text-indigo-900 font-medium text-center text-lg">
         <h1 className="text-4xl font-extrabold mb-6">About GPT YouTube Channel Recommender</h1>
         <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-indigo-400 pb-1">
           What is this?

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -4,11 +4,11 @@ import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
 
 function Homepage() {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-      <h1 className="text-3xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-4xl mx-auto">
+      <h1 className="text-3xl sm:text-6xl font-extrabold text-gray-900 mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
-      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
+      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-sm text-indigo-900 font-medium text-center text-lg">
         Input your current YouTube subscriptions, and get a curated new channel recommendation list!
       </section>
       <HomepageComponent />


### PR DESCRIPTION
## Summary
- lighten shadows in HomePage and About page sections
- simplify hero header style
- resize layout containers to be narrower

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843468744a083208bdb0497909e83ca