### PR TITLE
[gpt_reco_app] add brand design tokens

### DIFF
--- a/gpt_reco_app/index.html
+++ b/gpt_reco_app/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E👍%3C/text%3E%3C/svg%3E" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;800&display=swap" rel="stylesheet" />
     <title>Youtube2GPT</title>
   </head>
   <body>

--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -87,29 +87,29 @@ function HomepageComponent() {
   };
 
   return (
-    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10">
+    <main className="max-w-3xl mx-auto p-section bg-white rounded-lg shadow-lg mt-10">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">Set up your OpenAI API key</h2>
       <input
         type="text"
         placeholder="Enter your OpenAI API key"
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
-        className="w-full p-3 border border-gray-300 rounded-lg mb-6 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+        className="w-full p-3 border border-gray-300 rounded-lg mb-6 focus:outline-none focus:ring-2 focus:ring-brand-light focus:border-brand-light transition"
       />
       <button
         onClick={checkApiKey}
         disabled={loading || !apiKey}
-        className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
+        className="w-full py-3 bg-brand hover:bg-brand-dark focus:ring-4 focus:ring-brand-light text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
       >
         {loading ? 'Checking...' : 'Check and save API Key'}
       </button>
 
       {apiKey && cookieApiKeyLoaded && (
-      <div className="mt-6 flex justify-between items-center bg-green-100 border border-green-400 text-green-900 p-4 rounded-lg">
+      <div className="mt-6 flex justify-between items-center bg-accent/20 border border-accent text-accent p-4 rounded-lg">
         <p className="text-lg font-medium">API key is loaded from cookie.</p>
         <button
           onClick={deleteApiKey}
-          className="ml-4 py-2 px-4 bg-green-500 hover:bg-green-600 text-white font-semibold rounded-lg transition"
+          className="ml-4 py-2 px-4 bg-accent hover:bg-accent/80 text-white font-semibold rounded-lg transition"
         >
           Delete Key
         </button>
@@ -122,14 +122,14 @@ function HomepageComponent() {
             fadeOut ? 'opacity-0' : 'opacity-100'
           } ${
             checkResult.status === 'success'
-              ? 'bg-green-100 text-green-900 border border-green-400'
+              ? 'bg-accent/20 text-accent border border-accent'
               : 'bg-red-100 text-red-900 border border-red-400'
           }`}
           role="alert"
         >
           {checkResult.status === 'success' ? (
             <svg
-              className="w-6 h-6 mr-3 text-green-600"
+              className="w-6 h-6 mr-3 text-accent"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
               fill="currentColor"

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -3,19 +3,19 @@ import { Link } from 'react-router-dom';
 
 function Navbar() {
   return (
-    <nav className="bg-white border-b border-gray-300 shadow-sm">
+    <nav className="bg-white border-b border-brand-light shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center space-x-8">
             <Link to="/" className="flex items-center space-x-2" aria-label="Logo">
               <span role="img" aria-label="thumbs up" className="text-3xl">👍</span>
-              <span className="font-bold text-xl text-gray-900">GPT Recommender</span>
+              <span className="font-bold text-xl text-brand">GPT Recommender</span>
             </Link>
             <div className="flex space-x-6">
-              <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
+              <Link to="/" className="text-gray-700 hover:text-brand font-semibold">
                 Home
               </Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
+              <Link to="/about" className="text-gray-700 hover:text-brand font-semibold">
                 About
               </Link>
             </div>

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -62,7 +62,7 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
       <button
         onClick={getImprovedRecommendations}
         disabled={loading}
-        className="mb-4 w-full py-3 bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
+        className="mb-4 w-full py-3 bg-brand hover:bg-brand-dark focus:ring-4 focus:ring-brand-light text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
       >
         {loading ? 'Loading...' : 'Get Improved Recommendations'}
       </button>

--- a/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
@@ -62,10 +62,10 @@ function YouTubeRecommendationList({ recommendations, prompt }) {
 function getStatusStyle(status) {
   if (status === 200) {
     return {
-      liClass: 'p-3 border border-green-500 rounded bg-green-100 flex items-center justify-between',
+      liClass: 'p-3 border border-accent rounded bg-accent/20 flex items-center justify-between',
       icon: (
         <div className="tooltip" data-tooltip="Verified Link (HTTP 200)">
-          <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+          <svg className="w-5 h-5 text-accent" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
@@ -84,7 +84,7 @@ function getStatusStyle(status) {
     };
   } else if (status) {
     return {
-      liClass: 'p-3 border border-green-300 rounded bg-green-50 text-orange-600 flex items-center justify-between',
+      liClass: 'p-3 border border-brand-light rounded bg-brand-light/50 text-orange-600 flex items-center justify-between',
       icon: (
         <div className="tooltip" data-tooltip={`Link Status: HTTP ${status}`}>
           <svg className="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -113,7 +113,7 @@ function getStatusStyle(status) {
 
   function getDuplicateIcon() {
     return (
-      <span className="text-green-500 ml-2" title="Duplicate" aria-label="Duplicate">&#x267B;</span>
+      <span className="text-accent ml-2" title="Duplicate" aria-label="Duplicate">&#x267B;</span>
     );
   }
 
@@ -163,7 +163,7 @@ function getStatusStyle(status) {
         />
         <div
           className={`w-12 h-6 rounded-full transition-colors duration-300 ease-in-out ${
-            showDuplicates ? 'bg-indigo-600' : 'bg-gray-300'
+            showDuplicates ? 'bg-brand' : 'bg-gray-300'
           }`}
         >
           <div
@@ -198,7 +198,7 @@ function getStatusStyle(status) {
         }}
       >
         <span
-          className="text-indigo-700 font-semibold mb-2 md:mb-0"
+          className="text-brand font-semibold mb-2 md:mb-0"
           style={{ minWidth: '10rem' }}
         >
           {rec.channel_name}

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -71,14 +71,14 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg">
+    <section className="max-w-3xl mx-auto p-section mt-10 bg-white rounded-lg shadow-lg">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">YouTube Channel Recommender</h2>
       <textarea
         rows={5}
         placeholder="Paste your current YouTube subscriptions here (names and URLs if available)"
         value={inputText}
         onChange={(e) => setInputText(e.target.value)}
-        className="w-full p-3 border border-gray-300 rounded-lg mb-6 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+        className="w-full p-3 border border-gray-300 rounded-lg mb-6 resize-none focus:outline-none focus:ring-2 focus:ring-brand-light focus:border-brand-light transition"
       />
       <label className="block mb-4 text-gray-700 font-medium">
         Number of recommendations to make:
@@ -87,13 +87,13 @@ Do NOT recommend a channel that is already present in the input list.`;
           min="1"
           value={numRecommendations}
           onChange={(e) => setNumRecommendations(Number(e.target.value))}
-          className="ml-3 p-2 border border-gray-300 rounded w-20 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+          className="ml-3 p-2 border border-gray-300 rounded w-20 focus:outline-none focus:ring-2 focus:ring-brand-light focus:border-brand-light transition"
         />
       </label>
       <button
         onClick={getRecommendations}
         disabled={loading || !inputText}
-        className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
+        className="w-full py-3 bg-brand hover:bg-brand-dark focus:ring-4 focus:ring-brand-light text-white font-semibold rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition"
       >
         {loading ? 'Getting Recommendations...' : 'Get Recommendations'}
       </button>

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+@layer base {
+  body {
+    font-family: 'Poppins', sans-serif;
+    background-color: #f5f5f7;
+    @apply text-gray-900;
+  }
+}

--- a/gpt_reco_app/src/main.jsx
+++ b/gpt_reco_app/src/main.jsx
@@ -7,7 +7,7 @@ import App from './App.jsx'
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <HashRouter>
-      <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-indigo-50 overflow-x-hidden">
+      <div className="min-h-screen bg-gradient-to-br from-brand-light via-white to-brand-light overflow-x-hidden">
         <App />
       </div>
     </HashRouter>

--- a/gpt_reco_app/src/pages/About.jsx
+++ b/gpt_reco_app/src/pages/About.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 const About = () => {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
+      <section className="mb-10 p-6 bg-brand-light rounded-lg shadow-md text-brand-dark font-medium text-center text-lg">
         <h1 className="text-4xl font-extrabold mb-6">About GPT YouTube Channel Recommender</h1>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-indigo-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-brand pb-1">
           What is this?
         </h2>
         <p className="text-lg leading-relaxed text-left">
@@ -13,10 +13,10 @@ const About = () => {
         </p>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-indigo-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-brand pb-1">
           How does it work?
         </h2>
-        <ul className="list-disc list-inside text-indigo-900 text-base leading-relaxed space-y-2">
+        <ul className="list-disc list-inside text-brand-dark text-base leading-relaxed space-y-2">
           <li>Input your <strong>OpenAI API key</strong> securely on the homepage.</li>
           <li>Paste your current YouTube channel subscriptions (names and URLs).</li>
           <li>Specify the number of recommendations you want to receive.</li>
@@ -25,7 +25,7 @@ const About = () => {
         </ul>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-indigo-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-brand pb-1">
           Why use this app?
         </h2>
         <p className="text-lg leading-relaxed">
@@ -33,7 +33,7 @@ const About = () => {
         </p>
       </section>
       <section>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-indigo-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-brand pb-1">
           Future Plans 🚀
         </h2>
         <p className="text-lg leading-relaxed">

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -8,7 +8,7 @@ function Homepage() {
       <h1 className="text-3xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
-      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
+      <section className="mb-10 p-6 bg-brand-light rounded-lg shadow-md text-brand-dark font-medium text-center text-lg">
         Input your current YouTube subscriptions, and get a curated new channel recommendation list!
       </section>
       <HomepageComponent />

--- a/gpt_reco_app/tailwind.config.js
+++ b/gpt_reco_app/tailwind.config.js
@@ -4,7 +4,24 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#0f4c81',
+          dark: '#08315f',
+          light: '#dbe4f1',
+          muted: '#f5f5f7',
+        },
+        accent: '#36b3a8',
+        secondary: '#ff7e67',
+      },
+      spacing: {
+        section: '2.5rem',
+      },
+      fontFamily: {
+        brand: ['Poppins', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind config with brand colors, font and spacing
- use new brand palette across components
- load Poppins font and set global base styles

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843469082cc83209ddf8ce025ce2cdf