### PR TITLE
[gpt_reco_app] add CTA and clean navbar

### DIFF
--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -87,7 +87,10 @@ function HomepageComponent() {
   };
 
   return (
-    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10">
+    <main
+      id="get-started"
+      className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-12"
+    >
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">Set up your OpenAI API key</h2>
       <input
         type="text"

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -20,7 +20,12 @@ function Navbar() {
               </Link>
             </div>
           </div>
-          <div></div>
+          <a
+            href="#get-started"
+            className="px-4 py-2 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition"
+          >
+            Get Started
+          </a>
         </div>
       </div>
     </nav>

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -71,7 +71,7 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg">
+    <section className="max-w-3xl mx-auto p-8 mt-12 bg-white rounded-lg shadow-lg">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900">YouTube Channel Recommender</h2>
       <textarea
         rows={5}

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -8,8 +8,14 @@ function Homepage() {
       <h1 className="text-3xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
-      <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
-        Input your current YouTube subscriptions, and get a curated new channel recommendation list!
+      <section className="mb-12 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">
+        <p>Input your current YouTube subscriptions, and get a curated new channel recommendation list!</p>
+        <a
+          href="#get-started"
+          className="inline-block mt-4 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 transition"
+        >
+          Get Started
+        </a>
       </section>
       <HomepageComponent />
       <div className="mt-12">


### PR DESCRIPTION
## Summary
- add "Get Started" button to navbar
- add call-to-action section on homepage
- use consistent spacing between homepage sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843467f1d4483209c8efce0a0a55d98