### PR TITLE
[gpt_reco_app] expand coverage

### DIFF
--- a/gpt_reco_app/src/__tests__/HomepageComponent.test.jsx
+++ b/gpt_reco_app/src/__tests__/HomepageComponent.test.jsx
@@ -1,3 +1,4 @@
+import Cookies from "js-cookie";
 import { render, screen } from '@testing-library/react';
 import { test, expect } from 'vitest';
 import HomepageComponent from '../components/Homepage.jsx';
@@ -6,4 +7,11 @@ test('shows API key setup heading', () => {
   render(<HomepageComponent />);
   expect(screen.getByText(/set up your openai api key/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /check and save api key/i })).toBeInTheDocument();
+});
+
+test('shows delete button when API key cookie exists', async () => {
+  Cookies.set('openai_api_key', 'test');
+  render(<HomepageComponent />);
+  expect(await screen.findByText(/api key is loaded from cookie/i)).toBeInTheDocument();
+  Cookies.remove('openai_api_key');
 });

--- a/gpt_reco_app/src/__tests__/openaiHelpers.test.js
+++ b/gpt_reco_app/src/__tests__/openaiHelpers.test.js
@@ -1,0 +1,39 @@
+import { test, expect } from 'vitest';
+import Cookies from 'js-cookie';
+import { RecommendationSchema, RecommendationsResponse, getOpenAIApiKey } from '../utils/openaiHelpers.js';
+
+
+test('RecommendationSchema validates valid object', () => {
+  const data = {
+    channel_name: 'Test Channel',
+    channel_url: 'https://youtube.com/@test',
+    recommendation_reason: 'Because it is great',
+  };
+  const result = RecommendationSchema.safeParse(data);
+  expect(result.success).toBe(true);
+});
+
+test('RecommendationSchema rejects invalid object', () => {
+  const data = {
+    channel_name: 'Test Channel',
+    recommendation_reason: 'missing url',
+  };
+  const result = RecommendationSchema.safeParse(data);
+  expect(result.success).toBe(false);
+});
+
+test('RecommendationsResponse parses array of recommendations', () => {
+  const data = {
+    recommendations: [
+      { channel_name: 'A', channel_url: 'https://a.com', recommendation_reason: 'one' },
+    ],
+  };
+  const result = RecommendationsResponse.safeParse(data);
+  expect(result.success).toBe(true);
+});
+
+test('getOpenAIApiKey returns stored cookie value', () => {
+  Cookies.set('openai_api_key', 'abc123');
+  expect(getOpenAIApiKey()).toBe('abc123');
+  Cookies.remove('openai_api_key');
+});


### PR DESCRIPTION
## Summary
- add tests for openaiHelpers utilities
- verify Homepage component shows delete button when API key cookie is present

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684345377e9483208a52611d5b8261bc