### PR TITLE
[gpt_reco_app] apply brand styling to homepage title

### DIFF
--- a/gpt_reco_app/index.html
+++ b/gpt_reco_app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E👍%3C/text%3E%3C/svg%3E" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Youtube2GPT</title>
+    <title>GPT YouTube Channel Recommender</title>
   </head>
   <body>
     <div id="root"></div>

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -1,1 +1,4 @@
-@import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap');
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -5,7 +5,7 @@ import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
 function Homepage() {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-      <h1 className="text-3xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
+      <h1 className="text-3xl sm:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-brand-primary via-brand-secondary to-brand-accent drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
       <section className="mb-10 p-6 bg-indigo-100 rounded-lg shadow-md text-indigo-900 font-medium text-center text-lg">

--- a/gpt_reco_app/tailwind.config.js
+++ b/gpt_reco_app/tailwind.config.js
@@ -4,7 +4,20 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          primary: '#8b5cf6',
+          secondary: '#ec4899',
+          accent: '#3b82f6',
+          light: '#f5f3ff',
+          dark: '#312e81',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- import Inter font and set Tailwind base/style
- define brand color tokens and font family
- update homepage heading gradient to use brand colors
- sync index title with brand name

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68435e81c0988320bfdfb608af656200