### PR TITLE
[gpt_reco_app] Add CI pipeline for npm test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+        working-directory: gpt_reco_app
+      - name: Run tests
+        run: npm test
+        working-directory: gpt_reco_app


### PR DESCRIPTION
## Summary
- run Vitest when a pull request is opened

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843667546ac8320a11209010cdb3f39