### PR TITLE
[gpt_reco_app] Restrict CI to JS changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Run Tests
 on:
   pull_request:
     branches: ["*"]
+    paths:
+      - "**/*.js"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- run CI only on PRs that modify `.js` files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684368610d808320a8f51de8eeb65c90