### PR TITLE
[gpt_reco_app] apply font classes

### DIFF
--- a/gpt_reco_app/src/components/Footer.jsx
+++ b/gpt_reco_app/src/components/Footer.jsx
@@ -6,7 +6,7 @@ function Footer() {
     <footer className="bg-gray-100 py-4 mt-8">
       <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600">
         &copy; {new Date().getFullYear()} GPT Recommender. All rights reserved.
-        <div className="mt-2">
+        <div className="mt-2 font-secondary">
           <Link to="/privacy-policy" className="text-blue-600 hover:underline mx-2">
             Privacy Policy
           </Link>

--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -87,8 +87,8 @@ function HomepageComponent() {
   };
 
   return (
-    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10 font-primary">
-      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-secondary">Set up your OpenAI API key</h2>
+    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10 font-secondary">
+      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-primary">Set up your OpenAI API key</h2>
       <input
         type="text"
         placeholder="Enter your OpenAI API key"

--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -87,8 +87,8 @@ function HomepageComponent() {
   };
 
   return (
-    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10">
-      <h2 className="text-3xl font-extrabold mb-6 text-gray-900">Set up your OpenAI API key</h2>
+    <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10 font-primary">
+      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-secondary">Set up your OpenAI API key</h2>
       <input
         type="text"
         placeholder="Enter your OpenAI API key"

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -3,15 +3,15 @@ import { Link } from 'react-router-dom';
 
 function Navbar() {
   return (
-    <nav className="bg-white border-b border-gray-300 shadow-sm">
+    <nav className="bg-white border-b border-gray-300 shadow-sm font-primary">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center space-x-8">
-            <Link to="/" className="flex items-center space-x-2" aria-label="Logo">
+            <Link to="/" className="flex items-center space-x-2 font-accent" aria-label="Logo">
               <span role="img" aria-label="thumbs up" className="text-3xl">👍</span>
               <span className="font-bold text-xl text-gray-900">GPT Recommender</span>
             </Link>
-            <div className="flex space-x-6">
+            <div className="flex space-x-6 font-secondary">
               <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
                 Home
               </Link>

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -7,7 +7,7 @@ function Navbar() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center space-x-8">
-            <Link to="/" className="flex items-center space-x-2 font-accent" aria-label="Logo">
+            <Link to="/" className="flex items-center space-x-2 font-secondary" aria-label="Logo">
               <span role="img" aria-label="thumbs up" className="text-3xl">👍</span>
               <span className="font-bold text-xl text-gray-900">GPT Recommender</span>
             </Link>

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 function Navbar() {
   return (
-    <nav className="bg-white border-b border-gray-300 shadow-sm font-primary">
+    <nav className="bg-white border-b border-gray-300 shadow-sm font-secondary">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center space-x-8">

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -57,8 +57,8 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
   };
 
   return (
-    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md">
-      <h2 className="text-2xl font-semibold mb-4">Criticizer: Get Better Recommendations</h2>
+    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md font-primary">
+      <h2 className="text-2xl font-semibold mb-4 font-secondary">Criticizer: Get Better Recommendations</h2>
       <button
         onClick={getImprovedRecommendations}
         disabled={loading}

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -57,8 +57,8 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
   };
 
   return (
-    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md font-primary">
-      <h2 className="text-2xl font-semibold mb-4 font-secondary">Criticizer: Get Better Recommendations</h2>
+    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md font-secondary">
+      <h2 className="text-2xl font-semibold mb-4 font-primary">Criticizer: Get Better Recommendations</h2>
       <button
         onClick={getImprovedRecommendations}
         disabled={loading}

--- a/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
@@ -178,9 +178,9 @@ function getStatusStyle(status) {
 
 
   return (
-    <div className="bg-white">
+    <div className="bg-white font-primary">
       <label className="my-4 flex items-center cursor-pointer select-none">
-        <span className="mr-3 text-gray-800 font-semibold">Show Duplicates</span>
+        <span className="mr-3 text-gray-800 font-semibold font-secondary">Show Duplicates</span>
         <input
           type="checkbox"
           checked={showDuplicates}

--- a/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
@@ -178,7 +178,7 @@ function getStatusStyle(status) {
 
 
   return (
-    <div className="bg-white font-primary">
+    <div className="bg-white font-secondary">
       <label className="my-4 flex items-center cursor-pointer select-none">
         <span className="mr-3 text-gray-800 font-semibold font-secondary">Show Duplicates</span>
         <input

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -71,8 +71,8 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg">
-      <h2 className="text-3xl font-extrabold mb-6 text-gray-900">YouTube Channel Recommender</h2>
+    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg font-primary">
+      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-secondary">YouTube Channel Recommender</h2>
       <textarea
         rows={5}
         placeholder="Paste your current YouTube subscriptions here (names and URLs if available)"

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -71,8 +71,8 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg font-primary">
-      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-secondary">YouTube Channel Recommender</h2>
+    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg font-secondary">
+      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-primary">YouTube Channel Recommender</h2>
       <textarea
         rows={5}
         placeholder="Paste your current YouTube subscriptions here (names and URLs if available)"

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -1,22 +1,22 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Source+Sans+3:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Oswald:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
 @import "tailwindcss";
 
 .font-playfair-display {
   font-family: 'Playfair Display', serif;
 }
 body {
-  font-family: "Montserrat", sans-serif;
+  font-family: "Oswald", sans-serif;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Source Sans 3", sans-serif;
+  font-family: "Poppins", sans-serif;
 }
 
 .font-primary {
-  font-family: "Montserrat", sans-serif;
+  font-family: "Poppins", sans-serif;
 }
 .font-secondary {
-  font-family: "Source Sans 3", sans-serif;
+  font-family: "Oswald", sans-serif;
 }
 .font-accent {
   font-family: "Playfair Display", serif;

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -1,34 +1,22 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Poppins:wght@400;600&family=Bebas+Neue&family=Oswald:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Source+Sans+3:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
 @import "tailwindcss";
 
-.font-montserrat {
-  font-family: 'Montserrat', sans-serif;
-}
-.font-poppins {
-  font-family: 'Poppins', sans-serif;
-}
-.font-bebas-neue {
-  font-family: 'Bebas Neue', sans-serif;
-}
-.font-oswald {
-  font-family: 'Oswald', sans-serif;
-}
 .font-playfair-display {
   font-family: 'Playfair Display', serif;
 }
 body {
-  font-family: "Poppins", sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Oswald", sans-serif;
+  font-family: "Source Sans 3", sans-serif;
 }
 
 .font-primary {
-  font-family: "Poppins", sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 .font-secondary {
-  font-family: "Oswald", sans-serif;
+  font-family: "Source Sans 3", sans-serif;
 }
 .font-accent {
   font-family: "Playfair Display", serif;

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -1,25 +1,22 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Oswald:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Source Sans 3:wght@400;600&family=DM Serif Text:wght@400;700&display=swap');
 @import "tailwindcss";
 
-.font-playfair-display {
-  font-family: 'Playfair Display', serif;
-}
 body {
-  font-family: "Oswald", sans-serif;
+  font-family: "Source Sans 3", sans-serif;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Poppins", sans-serif;
+  font-family: "Montserrat", sans-serif;
 }
 
 .font-primary {
   font-family: "Poppins", sans-serif;
 }
 .font-secondary {
-  font-family: "Oswald", sans-serif;
+  font-family: "Source Sans 3", sans-serif;
 }
 .font-accent {
-  font-family: "Playfair Display", serif;
+  font-family: "DM Serif Text", serif;
 }
 
 

--- a/gpt_reco_app/src/pages/About.jsx
+++ b/gpt_reco_app/src/pages/About.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 const About = () => {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-primary">
       <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg">
-        <h1 className="text-4xl font-extrabold mb-6">About GPT YouTube Channel Recommender</h1>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1">
+        <h1 className="text-4xl font-extrabold mb-6 font-secondary">About GPT YouTube Channel Recommender</h1>
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
           What is this?
         </h2>
         <p className="text-lg leading-relaxed text-left">
@@ -13,7 +13,7 @@ const About = () => {
         </p>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
           How does it work?
         </h2>
         <ul className="list-disc list-inside text-primary-900 text-base leading-relaxed space-y-2">
@@ -25,7 +25,7 @@ const About = () => {
         </ul>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
           Why use this app?
         </h2>
         <p className="text-lg leading-relaxed">
@@ -33,7 +33,7 @@ const About = () => {
         </p>
       </section>
       <section>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
           Future Plans 🚀
         </h2>
         <p className="text-lg leading-relaxed">

--- a/gpt_reco_app/src/pages/About.jsx
+++ b/gpt_reco_app/src/pages/About.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 const About = () => {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-primary">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
       <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg">
-        <h1 className="text-4xl font-extrabold mb-6 font-secondary">About GPT YouTube Channel Recommender</h1>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
+        <h1 className="text-4xl font-extrabold mb-6 font-primary">About GPT YouTube Channel Recommender</h1>
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-primary">
           What is this?
         </h2>
         <p className="text-lg leading-relaxed text-left">
@@ -13,7 +13,7 @@ const About = () => {
         </p>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-primary">
           How does it work?
         </h2>
         <ul className="list-disc list-inside text-primary-900 text-base leading-relaxed space-y-2">
@@ -25,7 +25,7 @@ const About = () => {
         </ul>
       </section>
       <section className="mb-10">
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-primary">
           Why use this app?
         </h2>
         <p className="text-lg leading-relaxed">
@@ -33,7 +33,7 @@ const About = () => {
         </p>
       </section>
       <section>
-        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-secondary">
+        <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-primary">
           Future Plans 🚀
         </h2>
         <p className="text-lg leading-relaxed">

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -4,11 +4,11 @@ import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
 
 function Homepage() {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto">
-      <h1 className="text-3xl sm:text-6xl font-extrabold font-montserrat text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-primary">
+      <h1 className="text-3xl sm:text-6xl font-extrabold font-secondary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
-      <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg">
+      <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg font-accent">
         Input your current YouTube subscriptions, and get a curated recommendation list!
       </section>
       <HomepageComponent />

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -4,8 +4,8 @@ import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
 
 function Homepage() {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-primary">
-      <h1 className="text-3xl sm:text-6xl font-extrabold font-secondary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
+      <h1 className="text-3xl sm:text-6xl font-extrabold font-primary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
       <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg font-accent">

--- a/gpt_reco_app/src/pages/PrivacyPolicy.jsx
+++ b/gpt_reco_app/src/pages/PrivacyPolicy.jsx
@@ -2,30 +2,30 @@ import React from 'react';
 
 function PrivacyPolicy() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4 font-primary">
-      <h1 className="text-3xl font-bold mb-4 font-secondary">Privacy Policy</h1>
+    <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
+      <h1 className="text-3xl font-bold mb-4 font-primary">Privacy Policy</h1>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">🛡️ Our Commitment as an EU Company</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">🛡️ Our Commitment as an EU Company</h2>
       <p className="mb-6">
         We are proudly an EU-based company, which means we strictly adhere to the General Data Protection Regulation (GDPR). This regulation is one of the most rigorous data protection laws globally, designed to safeguard the personal data and privacy of individuals within the European Union. Being subject to GDPR means we are committed to maintaining the highest standards of data protection, ensuring transparency in how data is handled, and respecting your rights as a user. Our compliance reflects our dedication to protecting your privacy and building trust through responsible data practices.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">📜 Understanding GDPR</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">📜 Understanding GDPR</h2>
       <p className="mb-6">
         The GDPR is a comprehensive legal framework that governs the collection, processing, storage, and protection of personal data belonging to individuals in the EU. It emphasizes principles such as lawfulness, fairness, and transparency, requiring organizations to be clear about how they use personal data. It also enforces purpose limitation, meaning data must only be collected for specific, legitimate reasons, and data minimization, which restricts the amount of data collected to what is strictly necessary. Accuracy, storage limitation, integrity, confidentiality, and accountability are also core tenets, ensuring data is kept accurate, secure, and only for as long as needed. Importantly, GDPR empowers individuals with rights over their data, including access, correction, deletion, and portability.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">🔒 Our Data Collection Practices</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">🔒 Our Data Collection Practices</h2>
       <p className="mb-6">
         In full alignment with GDPR principles, we do not collect any personal data from our users. We neither store nor process any information that could identify you personally. This means that when you use our services, your privacy is inherently protected because no personal data is gathered or retained. Our platform is designed to operate without the need for personal information, ensuring that your interactions remain anonymous and secure at all times.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">📈 Logs and Data We Do Collect</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">📈 Logs and Data We Do Collect</h2>
       <p className="mb-6">
         While we do not collect personal data, we do record request timestamps in the Cloudflare console. These timestamps are automatically generated and serve purely for security and performance monitoring purposes. They do not contain any personal or identifying information and are used solely to maintain the reliability and security of our service infrastructure. This minimal data collection is essential for ensuring that our platform remains robust and responsive without compromising your privacy.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">🤝 Your Privacy Matters to Us</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">🤝 Your Privacy Matters to Us</h2>
       <p>
         Protecting your privacy is a fundamental priority for us. We take all necessary technical and organizational measures to ensure that any data we handle is kept safe, confidential, and secure. Our commitment extends beyond compliance; it is about fostering a trustworthy environment where you can use our services with confidence, knowing that your privacy is respected and safeguarded at every step.
       </p>

--- a/gpt_reco_app/src/pages/PrivacyPolicy.jsx
+++ b/gpt_reco_app/src/pages/PrivacyPolicy.jsx
@@ -2,30 +2,30 @@ import React from 'react';
 
 function PrivacyPolicy() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
-      <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
+    <div className="max-w-4xl mx-auto py-8 px-4 font-primary">
+      <h1 className="text-3xl font-bold mb-4 font-secondary">Privacy Policy</h1>
 
-      <h2 className="text-2xl font-semibold mb-3">🛡️ Our Commitment as an EU Company</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">🛡️ Our Commitment as an EU Company</h2>
       <p className="mb-6">
         We are proudly an EU-based company, which means we strictly adhere to the General Data Protection Regulation (GDPR). This regulation is one of the most rigorous data protection laws globally, designed to safeguard the personal data and privacy of individuals within the European Union. Being subject to GDPR means we are committed to maintaining the highest standards of data protection, ensuring transparency in how data is handled, and respecting your rights as a user. Our compliance reflects our dedication to protecting your privacy and building trust through responsible data practices.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">📜 Understanding GDPR</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">📜 Understanding GDPR</h2>
       <p className="mb-6">
         The GDPR is a comprehensive legal framework that governs the collection, processing, storage, and protection of personal data belonging to individuals in the EU. It emphasizes principles such as lawfulness, fairness, and transparency, requiring organizations to be clear about how they use personal data. It also enforces purpose limitation, meaning data must only be collected for specific, legitimate reasons, and data minimization, which restricts the amount of data collected to what is strictly necessary. Accuracy, storage limitation, integrity, confidentiality, and accountability are also core tenets, ensuring data is kept accurate, secure, and only for as long as needed. Importantly, GDPR empowers individuals with rights over their data, including access, correction, deletion, and portability.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">🔒 Our Data Collection Practices</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">🔒 Our Data Collection Practices</h2>
       <p className="mb-6">
         In full alignment with GDPR principles, we do not collect any personal data from our users. We neither store nor process any information that could identify you personally. This means that when you use our services, your privacy is inherently protected because no personal data is gathered or retained. Our platform is designed to operate without the need for personal information, ensuring that your interactions remain anonymous and secure at all times.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">📈 Logs and Data We Do Collect</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">📈 Logs and Data We Do Collect</h2>
       <p className="mb-6">
         While we do not collect personal data, we do record request timestamps in the Cloudflare console. These timestamps are automatically generated and serve purely for security and performance monitoring purposes. They do not contain any personal or identifying information and are used solely to maintain the reliability and security of our service infrastructure. This minimal data collection is essential for ensuring that our platform remains robust and responsive without compromising your privacy.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">🤝 Your Privacy Matters to Us</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">🤝 Your Privacy Matters to Us</h2>
       <p>
         Protecting your privacy is a fundamental priority for us. We take all necessary technical and organizational measures to ensure that any data we handle is kept safe, confidential, and secure. Our commitment extends beyond compliance; it is about fostering a trustworthy environment where you can use our services with confidence, knowing that your privacy is respected and safeguarded at every step.
       </p>

--- a/gpt_reco_app/src/pages/TermsOfService.jsx
+++ b/gpt_reco_app/src/pages/TermsOfService.jsx
@@ -2,57 +2,57 @@ import React from 'react';
 
 function TermsOfService() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
-      <h1 className="text-3xl font-bold mb-4">Terms of Service</h1>
+    <div className="max-w-4xl mx-auto py-8 px-4 font-primary">
+      <h1 className="text-3xl font-bold mb-4 font-secondary">Terms of Service</h1>
 
-      <h2 className="text-2xl font-semibold mt-6 mb-3">1. Acceptance of Terms</h2>
+      <h2 className="text-2xl font-semibold mt-6 mb-3 font-secondary">1. Acceptance of Terms</h2>
       <p className="mb-6">
         By accessing or using this service ("Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you must not use the Service.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">2. Description of the Service</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">2. Description of the Service</h2>
       <p className="mb-6">
         The Service is provided solely as a personal side project by the creators ("Providers") without any expectation of revenue. It generates YouTube channel recommendations using the GPT-4.1-nano model. Users must supply their own OpenAI API key, and the Service uses Cloudflare Workers solely to verify YouTube URLs. No official YouTube API is employed.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">3. User Obligations</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">3. User Obligations</h2>
       <ul className="list-disc list-inside mb-6">
         <li>Provide and maintain a valid OpenAI API key for use with the Service.</li>
         <li>Comply with all applicable laws, regulations, and third-party rights in your use of the Service.</li>
         <li>Refrain from misusing or attempting to disrupt the Service.</li>
       </ul>
 
-      <h2 className="text-2xl font-semibold mb-3">4. Intellectual Property</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">4. Intellectual Property</h2>
       <p className="mb-6">
         The Service’s underlying code and content are provided under the MIT License. All rights not expressly granted are reserved by the Providers.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">5. Disclaimer of Warranties</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">5. Disclaimer of Warranties</h2>
       <p className="mb-6">
         The Service is offered "as is" and "as available." The Providers make no warranties or representations of any kind, express or implied, including but not limited to merchantability, fitness for a particular purpose, or non-infringement.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">6. Limitation of Liability</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">6. Limitation of Liability</h2>
       <p className="mb-6">
         To the fullest extent permitted by law, the Providers shall not be liable for any direct, indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with your use of the Service, including any commercial or other reliance on the recommendations provided.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">7. Indemnification</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">7. Indemnification</h2>
       <p className="mb-6">
         You agree to indemnify, defend, and hold harmless the Providers from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys’ fees) arising out of or in any way connected with your use of the Service or violation of these Terms.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">8. Modifications to the Service or Terms</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">8. Modifications to the Service or Terms</h2>
       <p className="mb-6">
         The Providers may modify or discontinue the Service or revise these Terms at any time. Material changes will be communicated through the Service. Continued use after such changes constitutes acceptance.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">9. Governing Law</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">9. Governing Law</h2>
       <p className="mb-6">
         These Terms are governed by and construed in accordance with the laws of the Providers’ jurisdiction (within the EU), without regard to its conflict-of-law principles.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3">10. Contact</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-secondary">10. Contact</h2>
       <p>
         For questions about these Terms, you may reach the Providers through the contact information supplied in the project’s repository or website.
       </p>

--- a/gpt_reco_app/src/pages/TermsOfService.jsx
+++ b/gpt_reco_app/src/pages/TermsOfService.jsx
@@ -2,57 +2,57 @@ import React from 'react';
 
 function TermsOfService() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4 font-primary">
-      <h1 className="text-3xl font-bold mb-4 font-secondary">Terms of Service</h1>
+    <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
+      <h1 className="text-3xl font-bold mb-4 font-primary">Terms of Service</h1>
 
-      <h2 className="text-2xl font-semibold mt-6 mb-3 font-secondary">1. Acceptance of Terms</h2>
+      <h2 className="text-2xl font-semibold mt-6 mb-3 font-primary">1. Acceptance of Terms</h2>
       <p className="mb-6">
         By accessing or using this service ("Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you must not use the Service.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">2. Description of the Service</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">2. Description of the Service</h2>
       <p className="mb-6">
         The Service is provided solely as a personal side project by the creators ("Providers") without any expectation of revenue. It generates YouTube channel recommendations using the GPT-4.1-nano model. Users must supply their own OpenAI API key, and the Service uses Cloudflare Workers solely to verify YouTube URLs. No official YouTube API is employed.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">3. User Obligations</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">3. User Obligations</h2>
       <ul className="list-disc list-inside mb-6">
         <li>Provide and maintain a valid OpenAI API key for use with the Service.</li>
         <li>Comply with all applicable laws, regulations, and third-party rights in your use of the Service.</li>
         <li>Refrain from misusing or attempting to disrupt the Service.</li>
       </ul>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">4. Intellectual Property</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">4. Intellectual Property</h2>
       <p className="mb-6">
         The Service’s underlying code and content are provided under the MIT License. All rights not expressly granted are reserved by the Providers.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">5. Disclaimer of Warranties</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">5. Disclaimer of Warranties</h2>
       <p className="mb-6">
         The Service is offered "as is" and "as available." The Providers make no warranties or representations of any kind, express or implied, including but not limited to merchantability, fitness for a particular purpose, or non-infringement.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">6. Limitation of Liability</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">6. Limitation of Liability</h2>
       <p className="mb-6">
         To the fullest extent permitted by law, the Providers shall not be liable for any direct, indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with your use of the Service, including any commercial or other reliance on the recommendations provided.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">7. Indemnification</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">7. Indemnification</h2>
       <p className="mb-6">
         You agree to indemnify, defend, and hold harmless the Providers from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys’ fees) arising out of or in any way connected with your use of the Service or violation of these Terms.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">8. Modifications to the Service or Terms</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">8. Modifications to the Service or Terms</h2>
       <p className="mb-6">
         The Providers may modify or discontinue the Service or revise these Terms at any time. Material changes will be communicated through the Service. Continued use after such changes constitutes acceptance.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">9. Governing Law</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">9. Governing Law</h2>
       <p className="mb-6">
         These Terms are governed by and construed in accordance with the laws of the Providers’ jurisdiction (within the EU), without regard to its conflict-of-law principles.
       </p>
 
-      <h2 className="text-2xl font-semibold mb-3 font-secondary">10. Contact</h2>
+      <h2 className="text-2xl font-semibold mb-3 font-primary">10. Contact</h2>
       <p>
         For questions about these Terms, you may reach the Providers through the contact information supplied in the project’s repository or website.
       </p>


### PR DESCRIPTION
## Summary
- use font-primary, font-secondary and font-accent classes throughout pages
- categorize text on navigation bar and footer
- update homepage components with font styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845f6bbd46083209691429440629667