### PR TITLE
[gpt_reco_app] Add label for API key input

### DIFF
--- a/gpt_reco_app/src/__tests__/HomepageComponent.test.jsx
+++ b/gpt_reco_app/src/__tests__/HomepageComponent.test.jsx
@@ -6,6 +6,7 @@ import HomepageComponent from '../components/Homepage.jsx';
 test('shows API key setup heading', () => {
   render(<HomepageComponent />);
   expect(screen.getByText(/set up your openai api key/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/openai api key/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /check and save api key/i })).toBeInTheDocument();
 });
 

--- a/gpt_reco_app/src/components/Homepage.jsx
+++ b/gpt_reco_app/src/components/Homepage.jsx
@@ -90,7 +90,11 @@ function HomepageComponent() {
   return (
     <main className="max-w-3xl mx-auto p-8 bg-white rounded-lg shadow-lg mt-10 font-secondary">
       <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-primary">Set up your OpenAI API key</h2>
+      <label htmlFor="api-key-input" className="block mb-2 text-gray-700 font-medium">
+        OpenAI API key
+      </label>
       <input
+        id="api-key-input"
         type="text"
         placeholder="Enter your OpenAI API key"
         value={apiKey}


### PR DESCRIPTION
## Summary
- add a descriptive `<label>` for the API key input
- associate label with the input using `htmlFor`/`id`
- update tests for the new label

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68460146af64832095b258065d92b160