### PR TITLE
[gpt_reco_app] Add topic filtering to YouTube recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A React + Vite web application that leverages OpenAI's GPT-4.1-nano model to rec
 - Input and validate your OpenAI API key directly in the app.
 - Paste your current YouTube channel subscriptions (names and URLs).
 - Specify the number of new channel recommendations you want.
+- Filter recommendations by entering preferred topics or keywords.
 - Get AI-generated YouTube channel recommendations in JSON format.
 - View recommendations with live URL status checks (valid, not found, etc.) to ensure links are active. This feature uses a custom backend route to fetch the HTTP status of each recommended channel URL and displays status icons for verified, broken, or uncertain links.
 - Use the Criticizer component to get improved and refined YouTube channel recommendations based on your current subscriptions and previous suggestions. This component uses the OpenAI API to critique the initial recommendations and generate a better list, providing reasons for each improved suggestion.
@@ -68,8 +69,9 @@ If not set, it defaults to `https://head-checker.louispaulet13.workers.dev/?url=
 1. On the homepage, enter your OpenAI API key in the provided input field and click "Check API Key" to validate it.
 2. Paste your current YouTube channel subscriptions (names and URLs) into the text area.
 3. Specify how many new channel recommendations you want.
-4. Click "Get Recommendations" to fetch AI-generated YouTube channel suggestions.
-5. View the list of recommended channels with status indicators and links.
+4. (Optional) Enter your preferred topics or keywords to guide the recommendations.
+5. Click "Get Recommendations" to fetch AI-generated YouTube channel suggestions.
+6. View the list of recommended channels with status indicators and links.
 
 ## Technologies Used
 

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -11,6 +11,7 @@ function YouTubeRecommender() {
   const [loading, setLoading] = useState(false);
   const [numRecommendations, setNumRecommendations] = useState(10);
   const [prompt, setPrompt] = useState('');
+  const [topics, setTopics] = useState('');
 
   // Helper function to parse subscriptions from inputText
   const parseSubscriptions = (text) => {
@@ -35,14 +36,19 @@ function YouTubeRecommender() {
         dangerouslyAllowBrowser: true,
       });
 
+      const topicLine = topics.trim()
+        ? `Consider these preferred topics or keywords when making recommendations: ${topics}.`
+        : '';
+
       const newPrompt = `
 Based on the following list of YouTube recommendations, please suggest ${numRecommendations} new YouTube channels to watch.
+${topicLine}
 The input list of subscribed channels:
 
 ${inputText}
 
-Please respond ONLY in JSON format with a list of recommendations. 
-Each recommendation should have the following fields: 
+Please respond ONLY in JSON format with a list of recommendations.
+Each recommendation should have the following fields:
 "channel_name" (string), "channel_url" (string) where the URL is formatted as "https://www.youtube.com/@" + slug of the channel name,
 and "recommendation_reason" (string) which is a single short sentence explaining why this channel is recommended.
 
@@ -89,6 +95,16 @@ Do NOT recommend a channel that is already present in the input list.`;
           value={numRecommendations}
           onChange={(e) => setNumRecommendations(Number(e.target.value))}
           className="ml-3 p-2 border border-gray-300 rounded w-20 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
+        />
+      </label>
+      <label className="block mb-4 text-gray-700 font-medium">
+        Preferred topics or keywords:
+        <input
+          type="text"
+          placeholder="e.g. technology, cooking"
+          value={topics}
+          onChange={(e) => setTopics(e.target.value)}
+          className="mt-1 p-2 border border-gray-300 rounded w-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
         />
       </label>
       <button


### PR DESCRIPTION
## Summary
- add a `topics` input field for filtering recommendations
- incorporate user topics into the OpenAI prompt
- document new topic filtering feature in README

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684601609d4c8320bb3f65192a788703