### PR TITLE
[gpt_reco_app] document lint, build, test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ VITE_CHANNEL_CHECK_URL="https://example.com/?url=" npm run dev
 
 If not set, it defaults to `https://head-checker.louispaulet13.workers.dev/?url=`.
 
+## Linting, Building, and Testing
+
+The `gpt_reco_app/package.json` file defines handy scripts for common development tasks. From within the `gpt_reco_app` directory you can:
+
+- **Lint** the codebase with **ESLint**:
+
+  ```bash
+  npm run lint
+  ```
+
+- **Build** the project for production using **Vite**:
+
+  ```bash
+  npm run build
+  ```
+
+- **Run** the test suite powered by **Vitest**:
+
+  ```bash
+  npm test
+  ```
+
 ## Usage
 
 1. On the homepage, enter your OpenAI API key in the provided input field and click "Check API Key" to validate it.


### PR DESCRIPTION
## Summary
- add a new "Linting, Building, and Testing" section to README describing `npm run lint`, `npm run build`, and `npm test`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846035dca3083208948b148f5c89ed2