### PR TITLE
[gpt_reco_app] Update README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The repository primarily contains the web application inside the `gpt_reco_app` 
 1. Clone the repository:
 
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/louispaulet/gpt_recommender.git
    cd gpt_recommender/gpt_reco_app
    ```
 


### PR DESCRIPTION
## Summary
- fix the README clone command to point at the real repo URL

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684603602790832098c928b3b2adffa8