### PR TITLE
[gpt_reco_app] Enable dark theme

### DIFF
--- a/gpt_reco_app/src/components/Footer.jsx
+++ b/gpt_reco_app/src/components/Footer.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 
 function Footer() {
   return (
-    <footer className="bg-gray-100 py-4 mt-8">
-      <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600">
+    <footer className="bg-gray-100 dark:bg-dark-surface py-4 mt-8">
+      <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600 dark:text-dark-muted">
         &copy; {new Date().getFullYear()} GPT Recommender. All rights reserved.
         <div className="mt-2 font-secondary">
           <Link to="/privacy-policy" className="text-blue-600 hover:underline mx-2">

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -1,26 +1,53 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { FaMoon, FaSun } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
 function Navbar() {
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark';
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (darkMode) {
+      root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [darkMode]);
+
   return (
-    <nav className="bg-white border-b border-gray-300 shadow-sm font-secondary">
+    <nav className="bg-white dark:bg-dark-surface border-b border-gray-300 dark:border-dark-surface shadow-sm font-secondary">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center space-x-8">
             <Link to="/" className="flex items-center space-x-2 font-secondary" aria-label="Logo">
               <span role="img" aria-label="thumbs up" className="text-3xl">👍</span>
-              <span className="font-bold text-xl text-gray-900">GPT Recommender</span>
+              <span className="font-bold text-xl text-gray-900 dark:text-dark-text">GPT Recommender</span>
             </Link>
             <div className="flex space-x-6 font-secondary">
-              <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
+              <Link to="/" className="text-gray-700 dark:text-dark-text hover:text-blue-600 font-semibold">
                 Home
               </Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
+              <Link to="/about" className="text-gray-700 dark:text-dark-text hover:text-blue-600 font-semibold">
                 About
               </Link>
             </div>
           </div>
-          <div></div>
+          <div>
+            <button
+              onClick={() => setDarkMode(!darkMode)}
+              className="p-2 rounded focus:outline-none text-gray-700 dark:text-dark-text"
+              aria-label="Toggle dark mode"
+            >
+              {darkMode ? <FaSun /> : <FaMoon />}
+            </button>
+          </div>
         </div>
       </div>
     </nav>

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -58,8 +58,8 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
   };
 
   return (
-    <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md font-secondary">
-      <h2 className="text-2xl font-semibold mb-4 font-primary">Criticizer: Get Better Recommendations</h2>
+    <div className="mt-8 p-6 bg-gray-50 dark:bg-dark-card rounded-lg shadow-md font-secondary">
+      <h2 className="text-2xl font-semibold mb-4 font-primary text-gray-900 dark:text-dark-text">Criticizer: Get Better Recommendations</h2>
       <button
         onClick={getImprovedRecommendations}
         disabled={loading}

--- a/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommendationList.jsx
@@ -83,7 +83,7 @@ function getStatusStyle(status) {
   } else if (status === 404) {
     return {
       liClass:
-        'p-3 border border-gray-500 rounded bg-gray-200 text-gray-800 flex items-center justify-between',
+        'p-3 border border-gray-500 dark:border-dark-surface rounded bg-gray-200 dark:bg-dark-surface text-gray-800 dark:text-dark-text flex items-center justify-between',
       icon: (
         <div className="tooltip" data-tooltip="Incorrect Link (HTTP 404)">
           <svg
@@ -123,7 +123,7 @@ function getStatusStyle(status) {
   } else {
     // status null or undefined, loading or error
     return {
-      liClass: 'p-3 border border-gray-300 rounded bg-gray-50 flex items-center justify-between',
+      liClass: 'p-3 border border-gray-300 dark:border-dark-surface rounded bg-gray-50 dark:bg-dark-surface flex items-center justify-between',
       icon: null,
     };
   }
@@ -178,9 +178,9 @@ function getStatusStyle(status) {
 
 
   return (
-    <div className="bg-white font-secondary">
+    <div className="bg-white dark:bg-dark-card font-secondary">
       <label className="my-4 flex items-center cursor-pointer select-none">
-        <span className="mr-3 text-gray-800 font-semibold font-secondary">Show Duplicates</span>
+        <span className="mr-3 text-gray-800 dark:text-dark-text font-semibold font-secondary">Show Duplicates</span>
         <input
           type="checkbox"
           checked={showDuplicates}
@@ -190,11 +190,11 @@ function getStatusStyle(status) {
         />
         <div
           className={`w-12 h-6 rounded-full transition-colors duration-300 ease-in-out ${
-            showDuplicates ? 'bg-primary-600' : 'bg-gray-300'
+            showDuplicates ? 'bg-primary-600' : 'bg-gray-300 dark:bg-dark-muted'
           }`}
         >
           <div
-            className={`bg-white w-6 h-6 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
+            className={`bg-white dark:bg-dark-text w-6 h-6 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
               showDuplicates ? 'translate-x-6' : 'translate-x-0'
             }`}
           />
@@ -230,7 +230,7 @@ function getStatusStyle(status) {
         >
           {rec.channel_name}
         </span>
-        <p className="text-gray-700 text-sm italic mb-2 md:mb-0 md:flex-grow md:text-center">{rec.recommendation_reason}</p>
+        <p className="text-gray-700 dark:text-dark-text text-sm italic mb-2 md:mb-0 md:flex-grow md:text-center">{rec.recommendation_reason}</p>
         <div className="flex items-center space-x-2 flex-shrink-0">
           {/* Status Icon with Tooltip */}
           {icon && (

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -72,23 +72,23 @@ Do NOT recommend a channel that is already present in the input list.`;
   };
 
   return (
-    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white rounded-lg shadow-lg font-secondary">
-      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 font-primary">YouTube Channel Recommender</h2>
+    <section className="max-w-3xl mx-auto p-8 mt-10 bg-white dark:bg-dark-card rounded-lg shadow-lg font-secondary">
+      <h2 className="text-3xl font-extrabold mb-6 text-gray-900 dark:text-dark-text font-primary">YouTube Channel Recommender</h2>
       <textarea
         rows={5}
         placeholder="Paste your current YouTube subscriptions here (names and URLs if available)"
         value={inputText}
         onChange={(e) => setInputText(e.target.value)}
-        className="w-full p-3 border border-gray-300 rounded-lg mb-6 resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
+        className="w-full p-3 border border-gray-300 dark:border-dark-surface dark:bg-dark-surface dark:text-dark-text rounded-lg mb-6 resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
       />
-      <label className="block mb-4 text-gray-700 font-medium">
+      <label className="block mb-4 text-gray-700 dark:text-dark-text font-medium">
         Number of recommendations to make:
         <input
           type="number"
           min="1"
           value={numRecommendations}
           onChange={(e) => setNumRecommendations(Number(e.target.value))}
-          className="ml-3 p-2 border border-gray-300 rounded w-20 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
+          className="ml-3 p-2 border border-gray-300 dark:border-dark-surface dark:bg-dark-surface dark:text-dark-text rounded w-20 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
         />
       </label>
       <button
@@ -115,7 +115,7 @@ Do NOT recommend a channel that is already present in the input list.`;
             />
           </>
         ) : (
-          <pre className="mt-6 p-4 bg-gray-100 border border-gray-300 rounded-lg whitespace-pre-wrap">{recommendations}</pre>
+          <pre className="mt-6 p-4 bg-gray-100 dark:bg-dark-surface border border-gray-300 dark:border-dark-surface rounded-lg whitespace-pre-wrap dark:text-dark-text">{recommendations}</pre>
         )
       )}
     </section>

--- a/gpt_reco_app/src/index.css
+++ b/gpt_reco_app/src/index.css
@@ -3,6 +3,11 @@
 
 body {
   font-family: "Source Sans 3", sans-serif;
+  background-color: white;
+}
+
+.dark body {
+  background-color: var(--dark-bg);
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -30,6 +35,13 @@ h1, h2, h3, h4, h5, h6 {
   --primary-600: #4f46e5;
   --primary-700: #4338ca;
   --primary-900: #312e81;
+
+  /* Dark theme palette */
+  --dark-bg: #1f2937;
+  --dark-surface: #374151;
+  --dark-card: #1e293b;
+  --dark-text: #f3f4f6;
+  --dark-muted: #9ca3af;
 }
 
 /* Background colors */
@@ -61,3 +73,11 @@ h1, h2, h3, h4, h5, h6 {
 /* Ring utilities */
 .focus\:ring-primary-300:focus { --tw-ring-color: var(--primary-300); }
 .focus\:ring-primary-500:focus { --tw-ring-color: var(--primary-500); }
+
+/* Dark mode utilities */
+.dark .bg-dark-bg { background-color: var(--dark-bg); }
+.dark .bg-dark-surface { background-color: var(--dark-surface); }
+.dark .bg-dark-card { background-color: var(--dark-card); }
+.dark .text-dark-text { color: var(--dark-text); }
+.dark .text-dark-muted { color: var(--dark-muted); }
+.dark .border-dark-surface { border-color: var(--dark-surface); }

--- a/gpt_reco_app/tailwind.config.js
+++ b/gpt_reco_app/tailwind.config.js
@@ -1,0 +1,5 @@
+/* eslint-env node */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+};


### PR DESCRIPTION
## Summary
- set `darkMode: 'class'` in Tailwind config
- add dark palette variables and utilities
- update layout components with dark mode styles
- include a navbar toggle that remembers preference

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846012caf288320a228f9353c763ccc