### PR TITLE
[gpt_reco_app] improve unit tests

### DIFF
--- a/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
@@ -1,9 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import { test, expect } from 'vitest';
-import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
+import YouTubeRecommender, { parseSubscriptions } from '../components/YouTubeRecommender.jsx';
 
 test('button disabled without input', () => {
   render(<YouTubeRecommender />);
   const btn = screen.getByRole('button', { name: /get recommendations/i });
   expect(btn).toBeDisabled();
+});
+
+test('parseSubscriptions splits lines, commas and semicolons', () => {
+  const input = 'A, B\nC; D;;\n';
+  expect(parseSubscriptions(input)).toEqual(['A', 'B', 'C', 'D']);
+});
+
+test('parseSubscriptions returns empty array for empty input', () => {
+  expect(parseSubscriptions('')).toEqual([]);
 });

--- a/gpt_reco_app/src/__tests__/openaiHelpers.test.js
+++ b/gpt_reco_app/src/__tests__/openaiHelpers.test.js
@@ -37,3 +37,8 @@ test('getOpenAIApiKey returns stored cookie value', () => {
   expect(getOpenAIApiKey()).toBe('abc123');
   Cookies.remove('openai_api_key');
 });
+
+test('getOpenAIApiKey returns undefined when cookie missing', () => {
+  Cookies.remove('openai_api_key');
+  expect(getOpenAIApiKey()).toBeUndefined();
+});

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -5,6 +5,14 @@ import YouTubeRecommendationList from './YouTubeRecommendationList';
 import YouTubeCriticizer from './YouTubeCriticizer';
 import Spinner from './Spinner.jsx';
 import { RecommendationsResponse, getOpenAIApiKey } from '../utils/openaiHelpers.js';
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function parseSubscriptions(text) {
+  return text
+    .split(/[\n,;]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
 function YouTubeRecommender() {
   const [inputText, setInputText] = useState('');
   const [recommendations, setRecommendations] = useState(null);
@@ -14,13 +22,7 @@ function YouTubeRecommender() {
   const [topics, setTopics] = useState('');
 
   // Helper function to parse subscriptions from inputText
-  const parseSubscriptions = (text) => {
-    // Split by new lines, commas, or semicolons, trim spaces, and filter out empty strings
-    return text
-      .split(/[\n,;]+/)
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
-  };
+  // Defined outside the component for easier testing
 
   const getRecommendations = async () => {
     const currentApiKey = getOpenAIApiKey();


### PR DESCRIPTION
## Summary
- export `parseSubscriptions` from `YouTubeRecommender` component
- test `parseSubscriptions` logic
- add coverage for missing cookie case in `getOpenAIApiKey`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68460566774483209e9959df8ac2713a