### PR TITLE
[gpt_reco_app] restore mocks after tests

### DIFF
--- a/gpt_reco_app/src/__tests__/YouTubeRecommendationList.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommendationList.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { test, expect, vi } from 'vitest';
+import { afterEach, test, expect, vi } from 'vitest';
 import YouTubeRecommendationList from '../components/YouTubeRecommendationList.jsx';
 
 const recs = [
@@ -10,6 +10,8 @@ const recs = [
 ];
 
 globalThis.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ status: 200 }) }));
+
+afterEach(() => vi.restoreAllMocks());
 
 test('handles duplicate toggle', async () => {
   render(<YouTubeRecommendationList recommendations={recs} prompt="A" />);


### PR DESCRIPTION
## Summary
- ensure global mocks are cleaned up after `YouTubeRecommendationList` tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846080862d88320bed355c8ba75a621