### PR TITLE
[gpt_reco_app] silence react-router v7 warnings

### DIFF
--- a/gpt_reco_app/src/__tests__/App.test.jsx
+++ b/gpt_reco_app/src/__tests__/App.test.jsx
@@ -5,7 +5,10 @@ import App from '../App.jsx';
 
 test('renders homepage by default', () => {
   render(
-    <MemoryRouter initialEntries={["/"]}>
+    <MemoryRouter
+      initialEntries={["/"]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <App />
     </MemoryRouter>
   );

--- a/gpt_reco_app/src/__tests__/Footer.test.jsx
+++ b/gpt_reco_app/src/__tests__/Footer.test.jsx
@@ -5,7 +5,7 @@ import Footer from '../components/Footer.jsx';
 
 test('renders privacy and terms links', () => {
   render(
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Footer />
     </MemoryRouter>
   );

--- a/gpt_reco_app/src/__tests__/Navbar.test.jsx
+++ b/gpt_reco_app/src/__tests__/Navbar.test.jsx
@@ -5,7 +5,7 @@ import Navbar from '../components/Navbar.jsx';
 
 test('renders navigation links', () => {
   render(
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Navbar />
     </MemoryRouter>
   );

--- a/gpt_reco_app/src/main.jsx
+++ b/gpt_reco_app/src/main.jsx
@@ -6,7 +6,7 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <HashRouter>
+    <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-primary-50 overflow-x-hidden">
         <App />
       </div>


### PR DESCRIPTION
## Summary
- opt-in to React Router v7 flags in the main app
- update tests to use the same future flags

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68460b56943c8320a4a4a6ebf036aa16