### PR TITLE
[gpt_reco_app] add HTML subscription extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ From within the `gpt_reco_app` directory you can:
 5. Click "Get Recommendations" to fetch AI-generated YouTube channel suggestions.
 6. View the list of recommended channels with status indicators and links.
 
+## Extracting Subscriptions from HTML
+
+Save your YouTube subscriptions page with `Ctrl+S` and run the helper script to
+pull channel names and URLs:
+
+```bash
+python scripts/extract_subs_from_html.py path/to/YouTube.html
+```
+
+The script prints each channel name followed by its URL, separated by a tab.
+
+
 ## Technologies Used
 
 - React 19

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ channel recommendations.
   OpenAI API to critique the initial recommendations and generate a better list, providing
   reasons for each improved suggestion.
 - Toggle display of duplicate recommendations.
-- Import a saved YouTube subscriptions HTML file to extract channel names and links.
+- Import a saved YouTube subscriptions HTML file to extract channel names and links as a copyable CSV block.
 - Simple and clean UI built with React and TailwindCSS.
 
 ## Project Structure
@@ -116,6 +116,8 @@ python scripts/extract_subs_from_html.py path/to/YouTube.html
 ```
 
 The script prints each channel name followed by its URL, separated by a tab.
+
+In the web app, the channels are shown as a CSV block with a one-click copy button.
 
 
 ## Technologies Used

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ channel recommendations.
   OpenAI API to critique the initial recommendations and generate a better list, providing
   reasons for each improved suggestion.
 - Toggle display of duplicate recommendations.
+- Import a saved YouTube subscriptions HTML file to extract channel names and links.
 - Simple and clean UI built with React and TailwindCSS.
 
 ## Project Structure
@@ -108,8 +109,7 @@ From within the `gpt_reco_app` directory you can:
 
 ## Extracting Subscriptions from HTML
 
-Save your YouTube subscriptions page with `Ctrl+S` and run the helper script to
-pull channel names and URLs:
+Save your YouTube subscriptions page with `Ctrl+S` and either use the "Import HTML" page in the app or run the helper script below to pull channel names and URLs:
 
 ```bash
 python scripts/extract_subs_from_html.py path/to/YouTube.html

--- a/gpt_reco_app/src/App.jsx
+++ b/gpt_reco_app/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link, Routes, Route } from 'react-router-dom';
 import About from './pages/About.jsx';
 import Homepage from './pages/Homepage.jsx';
+import ImportSubscriptions from './pages/ImportSubscriptions.jsx';
 import PrivacyPolicy from './pages/PrivacyPolicy.jsx';
 import TermsOfService from './pages/TermsOfService.jsx';
 
@@ -17,6 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Homepage />} />
           <Route path="/about" element={<About />} />
+          <Route path="/import-html" element={<ImportSubscriptions />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
           <Route path="/terms-of-service" element={<TermsOfService />} />
         </Routes>

--- a/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
+++ b/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function parseSubscriptions(html) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const channels = Array.from(doc.querySelectorAll('ytd-channel-renderer'));
+  return channels
+    .map((ch) => {
+      const nameTag = ch.querySelector('ytd-channel-name yt-formatted-string#text');
+      const handleTag = ch.querySelector('a.channel-link[href*="/@"]');
+      if (nameTag && handleTag) {
+        return {
+          name: nameTag.textContent.trim(),
+          url: `https://www.youtube.com${handleTag.getAttribute('href').trim()}`,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+const HtmlSubscriptionImporter = () => {
+  const [results, setResults] = useState([]);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const html = ev.target.result;
+      const parsed = parseSubscriptions(html);
+      setResults(parsed);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="space-y-6">
+      <input
+        type="file"
+        accept="text/html"
+        onChange={handleFileChange}
+        className="block w-full text-sm text-gray-700"
+      />
+      {results.length > 0 && (
+        <ul className="list-disc pl-6">
+          {results.map((r) => (
+            <li key={r.url}>
+              <a href={r.url} className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">
+                {r.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default HtmlSubscriptionImporter;

--- a/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
+++ b/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
@@ -22,6 +22,7 @@ export function parseSubscriptions(html) {
 
 const HtmlSubscriptionImporter = () => {
   const [results, setResults] = useState([]);
+  const [copied, setCopied] = useState(false);
 
   const handleFileChange = (e) => {
     const file = e.target.files && e.target.files[0];
@@ -35,6 +36,20 @@ const HtmlSubscriptionImporter = () => {
     reader.readAsText(file);
   };
 
+  const csv = results
+    .map((r) => `"${r.name.replace(/"/g, '""')}",${r.url}`)
+    .join('\n');
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(csv);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* noop */
+    }
+  };
+
   return (
     <div className="space-y-6">
       <input
@@ -44,15 +59,21 @@ const HtmlSubscriptionImporter = () => {
         className="block w-full text-sm text-gray-700"
       />
       {results.length > 0 && (
-        <ul className="list-disc pl-6">
-          {results.map((r) => (
-            <li key={r.url}>
-              <a href={r.url} className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">
-                {r.name}
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-4">
+          <textarea
+            readOnly
+            value={csv}
+            rows={Math.min(10, results.length + 1)}
+            className="w-full border border-gray-300 p-2 font-mono text-sm"
+          />
+          <button
+            type="button"
+            onClick={copyToClipboard}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            {copied ? 'Copied!' : 'Copy to Clipboard'}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -18,6 +18,9 @@ function Navbar() {
               <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
                 About
               </Link>
+              <Link to="/import-html" className="text-gray-700 hover:text-blue-600 font-semibold">
+                Import HTML
+              </Link>
             </div>
           </div>
           <div></div>

--- a/gpt_reco_app/src/pages/ImportSubscriptions.jsx
+++ b/gpt_reco_app/src/pages/ImportSubscriptions.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import HtmlSubscriptionImporter from '../components/HtmlSubscriptionImporter.jsx';
+
+const ImportSubscriptions = () => {
+  return (
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary space-y-8">
+      <h1 className="text-3xl sm:text-5xl font-extrabold font-primary text-center">Import Subscriptions from HTML</h1>
+      <p className="text-center text-lg">Save your YouTube subscriptions page (Ctrl+S) and upload the file below.</p>
+      <HtmlSubscriptionImporter />
+    </div>
+  );
+};
+
+export default ImportSubscriptions;

--- a/scripts/extract_subs_from_html.py
+++ b/scripts/extract_subs_from_html.py
@@ -1,0 +1,37 @@
+import argparse
+from bs4 import BeautifulSoup
+from typing import List, Tuple
+
+
+def parse_subscriptions(html: str) -> List[Tuple[str, str]]:
+    """Return a list of (channel_name, channel_url) tuples from the HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    channels = soup.select("ytd-channel-renderer")
+    results = []
+    for ch in channels:
+        name_tag = ch.select_one("ytd-channel-name yt-formatted-string#text")
+        name = name_tag.text.strip() if name_tag else None
+        handle_tag = ch.select_one('a.channel-link[href*="/@"]')
+        handle = handle_tag['href'].strip() if handle_tag else None
+        if name and handle:
+            results.append((name, f"https://www.youtube.com{handle}"))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract YouTube channel names and URLs from a saved subscriptions HTML file",
+    )
+    parser.add_argument("file", help="Path to the saved YouTube subscriptions HTML page")
+    args = parser.parse_args()
+
+    with open(args.file, "r", encoding="utf-8") as f:
+        html = f.read()
+
+    results = parse_subscriptions(html)
+    for name, url in results:
+        print(f"{name}\t{url}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/extract_subs_from_html.py` for pulling channel names and links from a saved YouTube subscriptions page
- document how to use the new script in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684610d71fc48320a431d64011a04ddf