### PR TITLE
[gpt_reco_app] Improve import page UI

### DIFF
--- a/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
+++ b/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { FiCopy, FiUpload } from 'react-icons/fi';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function parseSubscriptions(html) {
@@ -52,8 +53,12 @@ const HtmlSubscriptionImporter = () => {
 
   return (
     <div className="p-6 bg-white rounded-lg shadow-lg space-y-6">
-      <label htmlFor="subscription-file" className="block text-lg font-medium text-gray-700">
-        Upload subscriptions HTML file
+      <label
+        htmlFor="subscription-file"
+        className="block text-lg font-medium text-gray-700 flex items-center space-x-2"
+      >
+        <FiUpload className="text-primary-600" />
+        <span>Upload subscriptions HTML file</span>
       </label>
       <input
         id="subscription-file"
@@ -76,9 +81,10 @@ const HtmlSubscriptionImporter = () => {
           <button
             type="button"
             onClick={copyToClipboard}
-            className="w-full py-2 bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:ring-primary-300 text-white font-semibold rounded-lg transition"
+            className="w-full py-2 bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:ring-primary-300 text-white font-semibold rounded-lg transition flex items-center justify-center space-x-2"
           >
-            {copied ? 'Copied!' : 'Copy to Clipboard'}
+            <FiCopy />
+            <span>{copied ? 'Copied!' : 'Copy to Clipboard'}</span>
           </button>
         </div>
       )}

--- a/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
+++ b/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
@@ -51,25 +51,32 @@ const HtmlSubscriptionImporter = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 bg-white rounded-lg shadow-lg space-y-6">
+      <label htmlFor="subscription-file" className="block text-lg font-medium text-gray-700">
+        Upload subscriptions HTML file
+      </label>
       <input
+        id="subscription-file"
         type="file"
         accept="text/html"
         onChange={handleFileChange}
-        className="block w-full text-sm text-gray-700"
+        className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
       />
       {results.length > 0 && (
         <div className="space-y-4">
+          <p className="text-sm text-gray-700">
+            {results.length} channels detected. Copy the CSV below:
+          </p>
           <textarea
             readOnly
             value={csv}
             rows={Math.min(10, results.length + 1)}
-            className="w-full border border-gray-300 p-2 font-mono text-sm"
+            className="w-full p-3 border border-gray-300 rounded-lg font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           />
           <button
             type="button"
             onClick={copyToClipboard}
-            className="px-4 py-2 bg-blue-600 text-white rounded"
+            className="w-full py-2 bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:ring-primary-300 text-white font-semibold rounded-lg transition"
           >
             {copied ? 'Copied!' : 'Copy to Clipboard'}
           </button>

--- a/gpt_reco_app/src/pages/ImportSubscriptions.jsx
+++ b/gpt_reco_app/src/pages/ImportSubscriptions.jsx
@@ -4,8 +4,12 @@ import HtmlSubscriptionImporter from '../components/HtmlSubscriptionImporter.jsx
 const ImportSubscriptions = () => {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary space-y-8">
-      <h1 className="text-3xl sm:text-5xl font-extrabold font-primary text-center">Import Subscriptions from HTML</h1>
-      <p className="text-center text-lg">Save your YouTube subscriptions page (Ctrl+S) and upload the file below.</p>
+      <h1 className="text-3xl sm:text-5xl font-extrabold font-primary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg text-center">
+        Import Your Subscriptions
+      </h1>
+      <section className="p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg">
+        Save your YouTube subscriptions page (Ctrl+S) and upload the file below to generate a CSV of your channels.
+      </section>
       <HtmlSubscriptionImporter />
     </div>
   );


### PR DESCRIPTION
## Summary
- refresh design on Import Subscriptions page
- add styled upload field and results area to HtmlSubscriptionImporter

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68461efaf2ac83209848aaf144d2128b