### PR TITLE
[gpt_reco_app] reorder about link in navbar

### DIFF
--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -15,11 +15,11 @@ function Navbar() {
               <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
                 Home
               </Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
-                About
-              </Link>
               <Link to="/import-html" className="text-gray-700 hover:text-blue-600 font-semibold">
                 Import HTML
+              </Link>
+              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
+                About
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- move the About nav item after Import HTML so it's last

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68461f1ef1f08320aa0a626bfa5ba93b