### PR TITLE
[gpt_reco_app] make footer inline

### DIFF
--- a/gpt_reco_app/src/components/Footer.jsx
+++ b/gpt_reco_app/src/components/Footer.jsx
@@ -4,17 +4,17 @@ import { Link } from 'react-router-dom';
 function Footer() {
   return (
     <footer className="bg-gray-100 py-4 mt-8">
-      <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600">
-        &copy; {new Date().getFullYear()} GPT Recommender. All rights reserved.
-        <div className="mt-2 font-secondary">
-          <Link to="/privacy-policy" className="text-blue-600 hover:underline mx-2">
+      <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600 flex flex-wrap items-center justify-center space-x-2">
+        <span>&copy; {new Date().getFullYear()} GPT Recommender. All rights reserved.</span>
+        <span className="font-secondary flex items-center space-x-2">
+          <Link to="/privacy-policy" className="text-blue-600 hover:underline">
             Privacy Policy
           </Link>
-          |
-          <Link to="/terms-of-service" className="text-blue-600 hover:underline mx-2">
+          <span>|</span>
+          <Link to="/terms-of-service" className="text-blue-600 hover:underline">
             Terms of Service
           </Link>
-        </div>
+        </span>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- update footer layout so links display on the same line

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68461f44c208832092ff6d8f932553d6