### PR TITLE
[gpt_reco_app] Fix duplicate YouTube URLs on import

### DIFF
--- a/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
+++ b/gpt_reco_app/src/components/HtmlSubscriptionImporter.jsx
@@ -12,9 +12,13 @@ export function parseSubscriptions(html) {
       const nameTag = ch.querySelector('ytd-channel-name yt-formatted-string#text');
       const handleTag = ch.querySelector('a.channel-link[href*="/@"]');
       if (nameTag && handleTag) {
+        const handleHref = handleTag.getAttribute('href').trim();
+        const url = handleHref.startsWith('http')
+          ? handleHref
+          : `https://www.youtube.com${handleHref}`;
         return {
           name: nameTag.textContent.trim(),
-          url: `https://www.youtube.com${handleTag.getAttribute('href').trim()}`,
+          url,
         };
       }
       return null;


### PR DESCRIPTION
## Summary
- prevent `HtmlSubscriptionImporter` from prefixing `https://www.youtube.com` when the imported URL already starts with `http`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684623d019048320ab646cfaaa9d7402