### PR TITLE
[gpt_reco_app] adjust navbar layout for mobile

### DIFF
--- a/gpt_reco_app/src/App.css
+++ b/gpt_reco_app/src/App.css
@@ -1,8 +1,15 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  margin: 0;
+  padding: 1rem;
   text-align: center;
+}
+
+@media (min-width: 640px) {
+  #root {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
 }
 
 .logo {

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -5,13 +5,13 @@ function Navbar() {
   return (
     <nav className="bg-white border-b border-gray-300 shadow-sm font-secondary">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16 items-center">
-          <div className="flex items-center space-x-8">
+        <div className="flex flex-col sm:flex-row justify-between sm:h-16 items-start sm:items-center py-4 sm:py-0">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-8">
             <Link to="/" className="flex items-center space-x-2 font-secondary" aria-label="Logo">
               <span role="img" aria-label="thumbs up" className="text-3xl">👍</span>
               <span className="font-bold text-xl text-gray-900">GPT Recommender</span>
             </Link>
-            <div className="flex space-x-6 font-secondary">
+            <div className="flex flex-col sm:flex-row font-secondary space-y-2 sm:space-y-0 sm:space-x-6">
               <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
                 Home
               </Link>

--- a/gpt_reco_app/src/components/YouTubeCriticizer.jsx
+++ b/gpt_reco_app/src/components/YouTubeCriticizer.jsx
@@ -59,7 +59,7 @@ function YouTubeCriticizer({ subscriptions, recommendations }) {
 
   return (
     <div className="mt-8 p-6 bg-gray-50 rounded-lg shadow-md font-secondary">
-      <h2 className="text-2xl font-semibold mb-4 font-primary">Criticizer: Get Better Recommendations</h2>
+      <h2 className="text-2xl font-semibold mb-4 font-primary">Criticizer: Get&nbsp;Better Recommendations</h2>
       <button
         onClick={getImprovedRecommendations}
         disabled={loading}


### PR DESCRIPTION
## Summary
- make nav links vertical on small screens
- set smaller root padding for mobile, larger on bigger screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846a3a1a8e88320bce9206d1b2b8b36