### PR TITLE
[gpt_reco_app] link to YouTube extraction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ From within the `gpt_reco_app` directory you can:
 
 ## Extracting Subscriptions from HTML
 
-Save your YouTube subscriptions page with `Ctrl+S` and either use the "Import HTML" page in the app or run the helper script below to pull channel names and URLs:
+Save your YouTube subscriptions page with `Ctrl+S` and either use the "YouTube Page Extraction" page in the app or run the helper script below to pull channel names and URLs:
 
 ```bash
 python scripts/extract_subs_from_html.py path/to/YouTube.html

--- a/gpt_reco_app/src/App.jsx
+++ b/gpt_reco_app/src/App.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, Routes, Route } from 'react-router-dom';
 import About from './pages/About.jsx';
 import Homepage from './pages/Homepage.jsx';
-import ImportSubscriptions from './pages/ImportSubscriptions.jsx';
+import YouTubePageExtraction from './pages/YouTubePageExtraction.jsx';
 import PrivacyPolicy from './pages/PrivacyPolicy.jsx';
 import TermsOfService from './pages/TermsOfService.jsx';
 
@@ -18,7 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Homepage />} />
           <Route path="/about" element={<About />} />
-          <Route path="/import-html" element={<ImportSubscriptions />} />
+          <Route path="/extract-youtube" element={<YouTubePageExtraction />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
           <Route path="/terms-of-service" element={<TermsOfService />} />
         </Routes>

--- a/gpt_reco_app/src/components/Navbar.jsx
+++ b/gpt_reco_app/src/components/Navbar.jsx
@@ -15,8 +15,8 @@ function Navbar() {
               <Link to="/" className="text-gray-700 hover:text-blue-600 font-semibold">
                 Home
               </Link>
-              <Link to="/import-html" className="text-gray-700 hover:text-blue-600 font-semibold">
-                Import HTML
+              <Link to="/extract-youtube" className="text-gray-700 hover:text-blue-600 font-semibold">
+                YouTube Page Extraction
               </Link>
               <Link to="/about" className="text-gray-700 hover:text-blue-600 font-semibold">
                 About

--- a/gpt_reco_app/src/components/YouTubeRecommender.jsx
+++ b/gpt_reco_app/src/components/YouTubeRecommender.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import OpenAI from 'openai';
 import { zodTextFormat } from 'openai/helpers/zod';
 import YouTubeRecommendationList from './YouTubeRecommendationList';
@@ -109,6 +110,13 @@ Do NOT recommend a channel that is already present in the input list.`;
           className="mt-1 p-2 border border-gray-300 rounded w-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition"
         />
       </label>
+      <p className="text-sm mb-4 text-gray-700">
+        Need to extract your subscriptions?{' '}
+        <Link to="/extract-youtube" className="text-primary-700 underline">
+          Use the YouTube Page Extraction page
+        </Link>
+        .
+      </p>
       <button
         onClick={getRecommendations}
         disabled={loading || !inputText}

--- a/gpt_reco_app/src/pages/YouTubePageExtraction.jsx
+++ b/gpt_reco_app/src/pages/YouTubePageExtraction.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import HtmlSubscriptionImporter from '../components/HtmlSubscriptionImporter.jsx';
 
-const ImportSubscriptions = () => {
+const YouTubePageExtraction = () => {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary space-y-8">
       <h1 className="text-3xl sm:text-5xl font-extrabold font-primary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg text-center">
@@ -28,4 +28,4 @@ const ImportSubscriptions = () => {
   );
 };
 
-export default ImportSubscriptions;
+export default YouTubePageExtraction;


### PR DESCRIPTION
## Summary
- rename ImportSubscriptions page to YouTubePageExtraction
- update routes and navbar to use `/extract-youtube`
- add a link from the recommender component to the extraction page
- mention the updated page name in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846a36707788320b8f39b51302f8528