### PR TITLE
[gpt_reco_app] fix failing vitest

### DIFF
--- a/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { test, expect } from 'vitest';
 import YouTubeRecommender, { parseSubscriptions } from '../components/YouTubeRecommender.jsx';
 
 test('button disabled without input', () => {
-  render(<YouTubeRecommender />);
+  render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <YouTubeRecommender />
+    </MemoryRouter>
+  );
   const btn = screen.getByRole('button', { name: /get recommendations/i });
   expect(btn).toBeDisabled();
 });


### PR DESCRIPTION
## Summary
- fix YouTubeRecommender test by rendering inside MemoryRouter

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6846b0e4f0cc83209b016cc5afce54e2