### PR TITLE
[gpt_reco_app] align footer color with navbar

### DIFF
--- a/gpt_reco_app/src/components/Footer.jsx
+++ b/gpt_reco_app/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 function Footer() {
   return (
-    <footer className="bg-gray-100 py-4 mt-8">
+    <footer className="bg-white py-4 mt-8">
       <div className="max-w-4xl mx-auto px-4 text-center text-sm font-accent text-gray-600 flex flex-wrap items-center justify-center space-x-2">
         <span>&copy; {new Date().getFullYear()} GPT Recommender. All rights reserved.</span>
         <span className="font-secondary flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- use `bg-white` for footer background to match navbar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846c457c280832083f5206c9c8826b2