### PR TITLE
[gpt_reco_app] Add NotFound page with routing and tests

### DIFF
--- a/gpt_reco_app/src/App.jsx
+++ b/gpt_reco_app/src/App.jsx
@@ -5,6 +5,7 @@ import Homepage from './pages/Homepage.jsx';
 import YouTubePageExtraction from './pages/YouTubePageExtraction.jsx';
 import PrivacyPolicy from './pages/PrivacyPolicy.jsx';
 import TermsOfService from './pages/TermsOfService.jsx';
+import NotFound from './pages/NotFound.jsx';
 
 import Navbar from './components/Navbar.jsx';
 
@@ -21,6 +22,7 @@ function App() {
           <Route path="/extract-youtube" element={<YouTubePageExtraction />} />
           <Route path="/privacy-policy" element={<PrivacyPolicy />} />
           <Route path="/terms-of-service" element={<TermsOfService />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </main>
       <Footer />

--- a/gpt_reco_app/src/__tests__/NotFound.test.jsx
+++ b/gpt_reco_app/src/__tests__/NotFound.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { test, expect } from 'vitest';
+import App from '../App.jsx';
+
+test('renders not found page for invalid route', () => {
+  render(
+    <MemoryRouter initialEntries={["/does-not-exist"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+});

--- a/gpt_reco_app/src/pages/NotFound.jsx
+++ b/gpt_reco_app/src/pages/NotFound.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function NotFound() {
+  return (
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto text-center font-secondary space-y-6">
+      <h1 className="text-4xl font-extrabold font-primary">Page Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+      <Link to="/" className="text-blue-600 hover:underline">
+        Back Home
+      </Link>
+    </div>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- add a simple `NotFound` page with a back-home link
- wire it into `<App/>` as a catch-all route
- test that invalid URLs show the new page

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846ce7aaad8832093bdc5f5305956cc