### PR TITLE
[gpt_reco_app] Lazy load page components

### DIFF
--- a/gpt_reco_app/src/App.jsx
+++ b/gpt_reco_app/src/App.jsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import { Link, Routes, Route } from 'react-router-dom';
-import About from './pages/About.jsx';
-import Homepage from './pages/Homepage.jsx';
-import YouTubePageExtraction from './pages/YouTubePageExtraction.jsx';
-import PrivacyPolicy from './pages/PrivacyPolicy.jsx';
-import TermsOfService from './pages/TermsOfService.jsx';
-import NotFound from './pages/NotFound.jsx';
+import React, { Suspense, lazy } from 'react';
+import { Routes, Route } from 'react-router-dom';
+const About = lazy(() => import('./pages/About.jsx'));
+const Homepage = lazy(() => import('./pages/Homepage.jsx'));
+const YouTubePageExtraction = lazy(() => import('./pages/YouTubePageExtraction.jsx'));
+const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy.jsx'));
+const TermsOfService = lazy(() => import('./pages/TermsOfService.jsx'));
+const NotFound = lazy(() => import('./pages/NotFound.jsx'));
 
 import Navbar from './components/Navbar.jsx';
+import Spinner from './components/Spinner.jsx';
 
 import Footer from './components/Footer.jsx';
 
@@ -16,14 +17,16 @@ function App() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow px-4 max-w-4xl mx-auto">
-        <Routes>
-          <Route path="/" element={<Homepage />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/extract-youtube" element={<YouTubePageExtraction />} />
-          <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-          <Route path="/terms-of-service" element={<TermsOfService />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<Spinner />}>
+          <Routes>
+            <Route path="/" element={<Homepage />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/extract-youtube" element={<YouTubePageExtraction />} />
+            <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+            <Route path="/terms-of-service" element={<TermsOfService />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </main>
       <Footer />
     </div>

--- a/gpt_reco_app/src/__tests__/App.test.jsx
+++ b/gpt_reco_app/src/__tests__/App.test.jsx
@@ -1,16 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { Suspense } from 'react';
 import { test, expect } from 'vitest';
 import App from '../App.jsx';
 
-test('renders homepage by default', () => {
+test('renders homepage by default', async () => {
   render(
     <MemoryRouter
       initialEntries={["/"]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
-      <App />
+      <Suspense>
+        <App />
+      </Suspense>
     </MemoryRouter>
   );
-  expect(screen.getByRole('heading', { name: /gpt youtube channel recommender/i })).toBeInTheDocument();
+  expect(
+    await screen.findByRole('heading', { name: /gpt youtube channel recommender/i })
+  ).toBeInTheDocument();
 });

--- a/gpt_reco_app/src/__tests__/NotFound.test.jsx
+++ b/gpt_reco_app/src/__tests__/NotFound.test.jsx
@@ -1,13 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { Suspense } from 'react';
 import { test, expect } from 'vitest';
 import App from '../App.jsx';
 
-test('renders not found page for invalid route', () => {
+test('renders not found page for invalid route', async () => {
   render(
     <MemoryRouter initialEntries={["/does-not-exist"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-      <App />
+      <Suspense>
+        <App />
+      </Suspense>
     </MemoryRouter>
   );
-  expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+  expect(
+    await screen.findByRole('heading', { name: /page not found/i })
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- switch page imports in `App` to `React.lazy`
- show `<Spinner />` while loading routes
- update tests for async loading

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846cfc3bee48320a51a268d5f620a63