### PR TITLE
[gpt_reco_app] Add robots.txt and document sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The repository primarily contains the web application inside the `gpt_reco_app` 
   - `YouTubeRecommender.jsx` – queries OpenAI for channel suggestions.
   - `YouTubeCriticizer.jsx` – asks OpenAI to refine the first list.
   - `YouTubeRecommendationList.jsx` – lists results and checks each URL with a Cloudflare worker.
+- `public/robots.txt` – allows search engines to crawl the site and points to the sitemap.
 
 ## Installation
 

--- a/gpt_reco_app/public/robots.txt
+++ b/gpt_reco_app/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://gpt-reco.thefrenchartist.dev/sitemap.xml


### PR DESCRIPTION
## Summary
- add `public/robots.txt` with crawl rules and sitemap link
- document the new file in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846d489d520832097b3ef082835fbfd