### PR TITLE
[gpt_reco_app] Update sitemap for hash router

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ graph/Twitter tags used for previews. If the site's domain or screenshot image
 changes, update these tags so search engines and social networks display the
 correct information.
 
+## Sitemap
+
+`gpt_reco_app/public/sitemap.xml` lists all public routes so crawlers can
+discover them. Whenever you add a new route in `src/App.jsx`, create a
+corresponding `<url>` entry using the canonical domain
+`https://gpt-reco.thefrenchartist.dev`.
+
 
 ## Notes
 

--- a/gpt_reco_app/public/sitemap.xml
+++ b/gpt_reco_app/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/</loc>
+  </url>
+  <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/about</loc>
+  </url>
+  <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/privacy-policy</loc>
+  </url>
+  <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/terms-of-service</loc>
+  </url>
+  <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/extract-youtube</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- update `sitemap.xml` to use `#/` paths for the HashRouter

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846d642d6e8832091804efad531ebbb