### PR TITLE
[gpt_reco_app] add html parser tests

### DIFF
--- a/gpt_reco_app/src/__tests__/HtmlSubscriptionImporter.test.jsx
+++ b/gpt_reco_app/src/__tests__/HtmlSubscriptionImporter.test.jsx
@@ -1,0 +1,44 @@
+import { test, expect } from 'vitest';
+import { parseSubscriptions } from '../components/HtmlSubscriptionImporter.jsx';
+
+const sampleHtml = `
+<ytd-channel-renderer>
+  <ytd-channel-name>
+    <yt-formatted-string id="text">Channel One</yt-formatted-string>
+  </ytd-channel-name>
+  <a class="channel-link" href="/@one"></a>
+</ytd-channel-renderer>
+<ytd-channel-renderer>
+  <ytd-channel-name>
+    <yt-formatted-string id="text">Channel Two</yt-formatted-string>
+  </ytd-channel-name>
+  <a class="channel-link" href="https://www.youtube.com/@two"></a>
+</ytd-channel-renderer>`;
+
+test('parseSubscriptions extracts channel names and urls', () => {
+  expect(parseSubscriptions(sampleHtml)).toEqual([
+    { name: 'Channel One', url: 'https://www.youtube.com/@one' },
+    { name: 'Channel Two', url: 'https://www.youtube.com/@two' },
+  ]);
+});
+
+test('parseSubscriptions skips items missing name or url', () => {
+  const html = `
+  <ytd-channel-renderer>
+    <ytd-channel-name></ytd-channel-name>
+    <a class="channel-link" href="/@x"></a>
+  </ytd-channel-renderer>
+  <ytd-channel-renderer>
+    <ytd-channel-name>
+      <yt-formatted-string id="text">Valid</yt-formatted-string>
+    </ytd-channel-name>
+    <a class="channel-link" href="/@valid"></a>
+  </ytd-channel-renderer>`;
+  expect(parseSubscriptions(html)).toEqual([
+    { name: 'Valid', url: 'https://www.youtube.com/@valid' },
+  ]);
+});
+
+test('parseSubscriptions returns empty array when no channels found', () => {
+  expect(parseSubscriptions('<div></div>')).toEqual([]);
+});

--- a/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
@@ -2,7 +2,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { test, expect } from 'vitest';
-import YouTubeRecommender, { parseSubscriptions } from '../components/YouTubeRecommender.jsx';
+import YouTubeRecommender, {
+  parseSubscriptions,
+  parseHtmlSubscriptions,
+} from '../components/YouTubeRecommender.jsx';
 
 test('button enabled without subscriptions', () => {
   render(
@@ -40,4 +43,38 @@ test('unchecking subscription list clears textarea', async () => {
   await user.click(checkbox);
   const textareaAgain = screen.getByPlaceholderText(/your subscriptions will appear here/i);
   expect(textareaAgain.value).toBe('');
+});
+
+test('parseHtmlSubscriptions extracts channel urls', () => {
+  const html = `
+  <ytd-channel-renderer>
+    <a class="channel-link" href="/@alpha"></a>
+  </ytd-channel-renderer>
+  <ytd-channel-renderer>
+    <a class="channel-link" href="https://www.youtube.com/@beta"></a>
+  </ytd-channel-renderer>`;
+  expect(parseHtmlSubscriptions(html)).toEqual([
+    'https://www.youtube.com/@alpha',
+    'https://www.youtube.com/@beta',
+  ]);
+});
+
+test('parseHtmlSubscriptions ignores items without channel link', () => {
+  const html = `
+    <ytd-channel-renderer></ytd-channel-renderer>
+    <ytd-channel-renderer>
+      <a class="channel-link" href="/@good"></a>
+    </ytd-channel-renderer>`;
+  expect(parseHtmlSubscriptions(html)).toEqual([
+    'https://www.youtube.com/@good',
+  ]);
+});
+
+test('parseHtmlSubscriptions returns empty array when no matches', () => {
+  expect(parseHtmlSubscriptions('<div></div>')).toEqual([]);
+});
+
+test('parseSubscriptions trims whitespace and ignores blanks', () => {
+  const input = '  One ;; , \n Two\n\nThree ';
+  expect(parseSubscriptions(input)).toEqual(['One', 'Two', 'Three']);
 });


### PR DESCRIPTION
## Summary
- add new parseSubscriptions tests for HtmlSubscriptionImporter
- expand YouTubeRecommender tests to cover parseHtmlSubscriptions and whitespace parsing

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846d5e51ad48320a6946958fce8b996