### PR TITLE
[gpt_reco_app] Add async and integration tests

### DIFF
--- a/gpt_reco_app/src/__tests__/HomepageFlow.test.jsx
+++ b/gpt_reco_app/src/__tests__/HomepageFlow.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Suspense } from 'react';
+import { afterEach, expect, test, vi } from 'vitest';
+
+let createMock;
+let parseMock;
+
+vi.mock('openai', () => ({
+  default: class {
+    responses = {
+      create: (...args) => createMock(...args),
+      parse: (...args) => parseMock(...args),
+    };
+  },
+}));
+
+import Homepage from '../pages/Homepage.jsx';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const recommendations = [
+  { channel_name: 'Flow', channel_url: 'https://flow.com', recommendation_reason: 'why' },
+];
+
+test('user can set api key and fetch recommendations', async () => {
+  createMock = vi.fn().mockResolvedValue({ output_text: 'ok' });
+  parseMock = vi.fn().mockResolvedValue({ output_parsed: { recommendations } });
+  globalThis.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ status: 200 }) }));
+
+  render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <Suspense>
+        <Homepage />
+      </Suspense>
+    </MemoryRouter>
+  );
+
+  const input = screen.getByLabelText(/openai api key/i);
+  await userEvent.type(input, 'abc');
+  await userEvent.click(screen.getByRole('button', { name: /check and save api key/i }));
+  await screen.findByText(/api key is valid/i);
+  document.cookie = 'openai_api_key=abc';
+  await userEvent.click(screen.getByRole('button', { name: /get recommendations/i }));
+  await waitFor(() => expect(parseMock).toHaveBeenCalled());
+});

--- a/gpt_reco_app/src/__tests__/YouTubeCriticizer.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeCriticizer.test.jsx
@@ -1,6 +1,22 @@
 import { render, screen } from '@testing-library/react';
-import { test, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, test, expect, vi } from 'vitest';
+
+let parseMock;
+vi.mock('openai', () => ({
+  default: class {
+    constructor() {}
+    responses = {
+      parse: (...args) => parseMock(...args),
+    };
+  },
+}));
+
 import YouTubeCriticizer from '../components/YouTubeCriticizer.jsx';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const subs = ['channel1'];
 const recs = [
@@ -11,4 +27,28 @@ test('renders criticizer section', () => {
   render(<YouTubeCriticizer subscriptions={subs} recommendations={recs} />);
   expect(screen.getByText(/criticizer: get better recommendations/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /get improved recommendations/i })).toBeInTheDocument();
+});
+
+test('fetches and displays improved recommendations', async () => {
+  parseMock = vi.fn().mockResolvedValue({
+    output_parsed: {
+      recommendations: [
+        { channel_name: 'better', channel_url: 'https://b.com', recommendation_reason: 'why' },
+      ],
+    },
+  });
+  globalThis.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ status: 200 }) }));
+  render(<YouTubeCriticizer subscriptions={subs} recommendations={recs} />);
+  const btn = screen.getAllByRole('button', { name: /get improved recommendations/i })[0];
+  await userEvent.click(btn);
+  expect(await screen.findByText('better')).toBeInTheDocument();
+});
+
+test('shows error when fetch fails', async () => {
+  parseMock = vi.fn().mockRejectedValue(new Error('bad'));
+  globalThis.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ status: 200 }) }));
+  render(<YouTubeCriticizer subscriptions={subs} recommendations={recs} />);
+  const btn = screen.getAllByRole('button', { name: /get improved recommendations/i })[0];
+  await userEvent.click(btn);
+  expect(await screen.findByText(/error fetching improved recommendations/i)).toBeInTheDocument();
 });

--- a/gpt_reco_app/src/__tests__/YouTubeRecommendationList.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommendationList.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, test, expect, vi } from 'vitest';
 import YouTubeRecommendationList from '../components/YouTubeRecommendationList.jsx';
@@ -19,4 +19,14 @@ test('handles duplicate toggle', async () => {
   const toggle = screen.getByLabelText('Toggle display of duplicate recommendations');
   await userEvent.click(toggle);
   expect(screen.getAllByRole('link').length).toBe(2);
+});
+
+test('fetches url statuses', async () => {
+  globalThis.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 200 }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 404 }) });
+  render(<YouTubeRecommendationList recommendations={recs.slice(0, 2)} />);
+  await screen.findAllByRole('link');
+  await waitFor(() => expect(globalThis.fetch.mock.calls.length).toBeGreaterThan(0));
 });


### PR DESCRIPTION
## Summary
- add async success & error tests for `YouTubeCriticizer`
- expand `YouTubeRecommendationList` coverage for URL status fetch
- create integration test covering API key flow and recommendation fetching

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846ddf4abd083208f73868436469c75