### PR TITLE
[gpt_reco_app] Add font preconnect links

### DIFF
--- a/gpt_reco_app/index.html
+++ b/gpt_reco_app/index.html
@@ -16,6 +16,8 @@
     <meta name="twitter:description" content="GPT-powered recommendations for new YouTube channels." />
     <meta name="twitter:image" content="/default_screenshot.png" />
     <title>Youtube2GPT</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- preconnect to Google Fonts in `index.html`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e18c46b08320bcb22380f91e4668