### PR TITLE
[gpt_reco_app] generate sitemap from routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ From within the `gpt_reco_app` directory you can:
   npm run build
   ```
 
+- **Generate** the sitemap from defined routes:
+
+  ```bash
+  npm run sitemap
+  ```
+
 - **Run** the test suite powered by **Vitest**:
 
   ```bash
@@ -161,8 +167,10 @@ correct information.
 ## Sitemap
 
 `gpt_reco_app/public/sitemap.xml` lists all public routes so crawlers can
-discover them. Whenever you add a new route in `src/App.jsx`, create a
-corresponding `<url>` entry using the canonical domain
+discover them. Run `npm run sitemap` in the `gpt_reco_app` directory to
+generate this file automatically from the routes defined in `src/App.jsx`.
+The command is executed before `npm run deploy`, so remember to run it
+whenever deploying the site. The sitemap uses the canonical domain
 `https://gpt-reco.thefrenchartist.dev`.
 
 

--- a/gpt_reco_app/package.json
+++ b/gpt_reco_app/package.json
@@ -9,7 +9,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "predeploy": "npm run build",
+    "sitemap": "node ../scripts/update_sitemap.js",
+    "predeploy": "npm run sitemap && npm run build",
     "deploy": "gh-pages -d dist",
     "test": "vitest run"
   },

--- a/gpt_reco_app/public/sitemap.xml
+++ b/gpt_reco_app/public/sitemap.xml
@@ -7,12 +7,12 @@
     <loc>https://gpt-reco.thefrenchartist.dev/#/about</loc>
   </url>
   <url>
+    <loc>https://gpt-reco.thefrenchartist.dev/#/extract-youtube</loc>
+  </url>
+  <url>
     <loc>https://gpt-reco.thefrenchartist.dev/#/privacy-policy</loc>
   </url>
   <url>
     <loc>https://gpt-reco.thefrenchartist.dev/#/terms-of-service</loc>
-  </url>
-  <url>
-    <loc>https://gpt-reco.thefrenchartist.dev/#/extract-youtube</loc>
   </url>
 </urlset>

--- a/scripts/update_sitemap.js
+++ b/scripts/update_sitemap.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const appFile = path.join(__dirname, '..', 'gpt_reco_app', 'src', 'App.jsx');
+const sitemapFile = path.join(__dirname, '..', 'gpt_reco_app', 'public', 'sitemap.xml');
+const baseUrl = 'https://gpt-reco.thefrenchartist.dev';
+
+const content = fs.readFileSync(appFile, 'utf-8');
+const routeRegex = /<Route\s+path=["']([^"']+)["']/g;
+const paths = new Set();
+let match;
+while ((match = routeRegex.exec(content))) {
+  const p = match[1];
+  if (p && p !== '*') {
+    paths.add(p);
+  }
+}
+
+const urls = Array.from(paths).map((p) => {
+  const sanitized = p.startsWith('/') ? p : `/${p}`;
+  return `  <url>\n    <loc>${baseUrl}/#${sanitized}</loc>\n  </url>`;
+});
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>\n`;
+
+fs.writeFileSync(sitemapFile, xml, 'utf-8');
+console.log(`Updated sitemap with ${urls.length} routes.`);


### PR DESCRIPTION
## Summary
- add `update_sitemap.js` script to write `public/sitemap.xml`
- wire script into `npm` scripts
- document sitemap script usage
- regenerate `sitemap.xml`

## Testing
- `npm run sitemap`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e26740e08320ac3870b2b6419607