### PR TITLE
[gpt_reco_app] add page metadata with react-helmet

### DIFF
--- a/gpt_reco_app/index.html
+++ b/gpt_reco_app/index.html
@@ -6,15 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="GPT-powered recommendations for new YouTube channels." />
     <link rel="canonical" href="https://gpt-reco.thefrenchartist.dev/" />
-    <meta property="og:title" content="Youtube2GPT" />
-    <meta property="og:description" content="GPT-powered recommendations for new YouTube channels." />
-    <meta property="og:url" content="https://gpt-reco.thefrenchartist.dev/" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="/default_screenshot.png" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Youtube2GPT" />
-    <meta name="twitter:description" content="GPT-powered recommendations for new YouTube channels." />
-    <meta name="twitter:image" content="/default_screenshot.png" />
     <title>Youtube2GPT</title>
   </head>
   <body>

--- a/gpt_reco_app/package-lock.json
+++ b/gpt_reco_app/package-lock.json
@@ -13,6 +13,7 @@
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-helmet": "^6.1.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0",
         "react-spinners": "^0.17.0",
@@ -4568,6 +4569,33 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-helmet/node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-icons": {

--- a/gpt_reco_app/package.json
+++ b/gpt_reco_app/package.json
@@ -19,6 +19,7 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-helmet": "^6.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.23.0",
     "react-spinners": "^0.17.0",

--- a/gpt_reco_app/src/pages/About.jsx
+++ b/gpt_reco_app/src/pages/About.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 
 const About = () => {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
+    <>
+      <Helmet>
+        <title>About - GPT YouTube Channel Recommender</title>
+        <meta
+          name="description"
+          content="Learn more about the GPT YouTube Channel Recommender project."
+        />
+        <link
+          rel="canonical"
+          href="https://gpt-reco.thefrenchartist.dev/about"
+        />
+      </Helmet>
+      <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
       <section className="mb-10 p-6 bg-primary-100 rounded-lg shadow-md text-primary-900 font-medium text-center text-lg">
         <h1 className="text-4xl font-extrabold mb-6 font-primary">About GPT YouTube Channel Recommender</h1>
         <h2 className="text-2xl font-extrabold mb-3 tracking-wide uppercase border-b-2 border-primary-400 pb-1 font-primary">
@@ -40,7 +53,8 @@ const About = () => {
           We plan to extend the app's capabilities to recommend individual YouTube videos and other content types, enhancing your personalized discovery experience.
         </p>
       </section>
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/gpt_reco_app/src/pages/Homepage.jsx
+++ b/gpt_reco_app/src/pages/Homepage.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import HomepageComponent from '../components/Homepage.jsx';
 import YouTubeRecommender from '../components/YouTubeRecommender.jsx';
+import { Helmet } from 'react-helmet';
 
 function Homepage() {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
+    <>
+      <Helmet>
+        <title>GPT YouTube Channel Recommender</title>
+        <meta
+          name="description"
+          content="Generate personalized YouTube channel recommendations using GPT."
+        />
+        <link rel="canonical" href="https://gpt-reco.thefrenchartist.dev/" />
+      </Helmet>
+      <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary">
       <h1 className="text-3xl sm:text-6xl font-extrabold font-primary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg mb-12 text-center">
         GPT YouTube Channel Recommender
       </h1>
@@ -15,7 +25,8 @@ function Homepage() {
       <div className="mt-12">
         <YouTubeRecommender />
       </div>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/gpt_reco_app/src/pages/NotFound.jsx
+++ b/gpt_reco_app/src/pages/NotFound.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 
 function NotFound() {
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto text-center font-secondary space-y-6">
+    <>
+      <Helmet>
+        <title>Page Not Found</title>
+        <meta name="description" content="This page could not be located." />
+        <link rel="canonical" href="https://gpt-reco.thefrenchartist.dev/" />
+      </Helmet>
+      <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto text-center font-secondary space-y-6">
       <h1 className="text-4xl font-extrabold font-primary">Page Not Found</h1>
       <p>The page you are looking for does not exist.</p>
       <Link to="/" className="text-blue-600 hover:underline">
         Back Home
       </Link>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/gpt_reco_app/src/pages/YouTubePageExtraction.jsx
+++ b/gpt_reco_app/src/pages/YouTubePageExtraction.jsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import { MdArrowBack } from 'react-icons/md';
 import HtmlSubscriptionImporter from '../components/HtmlSubscriptionImporter.jsx';
 
@@ -8,7 +9,19 @@ const YouTubePageExtraction = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary space-y-8">
+    <>
+      <Helmet>
+        <title>Extract Your YouTube Subscriptions</title>
+        <meta
+          name="description"
+          content="Instructions to export your subscribed channels from YouTube."
+        />
+        <link
+          rel="canonical"
+          href="https://gpt-reco.thefrenchartist.dev/extract-youtube"
+        />
+      </Helmet>
+      <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto font-secondary space-y-8">
       <h1 className="text-3xl sm:text-5xl font-extrabold font-primary text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-600 drop-shadow-lg text-center">
         Extract Your Subscriptions
       </h1>
@@ -36,7 +49,8 @@ const YouTubePageExtraction = () => {
         <MdArrowBack size={24} />
         Get back to youtube recomender
       </button>
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/gpt_reco_app/src/pages/legal/PrivacyPolicy.jsx
+++ b/gpt_reco_app/src/pages/legal/PrivacyPolicy.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 
 function PrivacyPolicy() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
+    <>
+      <Helmet>
+        <title>Privacy Policy</title>
+        <meta
+          name="description"
+          content="Our commitment to protecting your data and privacy."
+        />
+        <link
+          rel="canonical"
+          href="https://gpt-reco.thefrenchartist.dev/privacy-policy"
+        />
+      </Helmet>
+      <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
       <h1 className="text-3xl font-bold mb-4 font-primary">Privacy Policy</h1>
 
       <h2 className="text-2xl font-semibold mb-3 font-primary">🛡️ Our Commitment as an EU Company</h2>
@@ -29,7 +42,8 @@ function PrivacyPolicy() {
       <p>
         Protecting your privacy is a fundamental priority for us. We take all necessary technical and organizational measures to ensure that any data we handle is kept safe, confidential, and secure. Our commitment extends beyond compliance; it is about fostering a trustworthy environment where you can use our services with confidence, knowing that your privacy is respected and safeguarded at every step.
       </p>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/gpt_reco_app/src/pages/legal/TermsOfService.jsx
+++ b/gpt_reco_app/src/pages/legal/TermsOfService.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 
 function TermsOfService() {
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
+    <>
+      <Helmet>
+        <title>Terms of Service</title>
+        <meta
+          name="description"
+          content="Rules for using GPT YouTube Channel Recommender."
+        />
+        <link
+          rel="canonical"
+          href="https://gpt-reco.thefrenchartist.dev/terms-of-service"
+        />
+      </Helmet>
+      <div className="max-w-4xl mx-auto py-8 px-4 font-secondary">
       <h1 className="text-3xl font-bold mb-4 font-primary">Terms of Service</h1>
 
       <h2 className="text-2xl font-semibold mt-6 mb-3 font-primary">1. Acceptance of Terms</h2>
@@ -56,7 +69,8 @@ function TermsOfService() {
       <p>
         For questions about these Terms, you may reach the Providers through the contact information supplied in the project’s repository or website.
       </p>
-    </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- integrate `react-helmet` for page-level metadata management
- add Helmet tags to all pages with unique title, description and canonical link
- prune meta tags in `index.html` to simple fallbacks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e1682d10832099a747a7a6cb588f