### PR TITLE
[gpt_reco_app] replace spinner fallback with page skeleton

### DIFF
--- a/gpt_reco_app/src/App.jsx
+++ b/gpt_reco_app/src/App.jsx
@@ -8,7 +8,7 @@ const TermsOfService = lazy(() => import('./pages/legal/TermsOfService.jsx'));
 const NotFound = lazy(() => import('./pages/NotFound.jsx'));
 
 import Navbar from './components/Navbar.jsx';
-import Spinner from './components/Spinner.jsx';
+import PageSkeleton from './components/PageSkeleton.jsx';
 
 import Footer from './components/Footer.jsx';
 
@@ -17,7 +17,7 @@ function App() {
     <div className="flex flex-col min-h-screen">
       <Navbar />
       <main className="flex-grow px-4 max-w-4xl mx-auto">
-        <Suspense fallback={<Spinner />}>
+        <Suspense fallback={<PageSkeleton />}>
           <Routes>
             <Route path="/" element={<Homepage />} />
             <Route path="/about" element={<About />} />

--- a/gpt_reco_app/src/components/PageSkeleton.jsx
+++ b/gpt_reco_app/src/components/PageSkeleton.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function PageSkeleton() {
+  return (
+    <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-5xl mx-auto animate-pulse space-y-6">
+      <div className="h-10 bg-gray-200 rounded w-3/4" />
+      <div className="space-y-3">
+        <div className="h-4 bg-gray-200 rounded" />
+        <div className="h-4 bg-gray-200 rounded w-5/6" />
+        <div className="h-4 bg-gray-200 rounded w-2/3" />
+      </div>
+      <div className="h-64 bg-gray-200 rounded" />
+    </div>
+  );
+}
+
+export default PageSkeleton;


### PR DESCRIPTION
## Summary
- add `PageSkeleton` component with placeholder layout
- use `PageSkeleton` as `Suspense` fallback in `App.jsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e51e3e20832088698a456ea2f689