### PR TITLE
[gpt_reco_app] Add basic integration test

### DIFF
--- a/gpt_reco_app/src/__tests__/YouTubePageExtraction.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubePageExtraction.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Suspense } from 'react';
+import { test, expect } from 'vitest';
+import App from '../App.jsx';
+
+test('renders extraction page heading via router', async () => {
+  render(
+    <MemoryRouter initialEntries={["/extract-youtube"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <Suspense>
+        <App />
+      </Suspense>
+    </MemoryRouter>
+  );
+  expect(
+    await screen.findByRole('heading', { name: /extract your subscriptions/i })
+  ).toBeInTheDocument();
+});

--- a/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
+++ b/gpt_reco_app/src/__tests__/YouTubeRecommender.test.jsx
@@ -2,6 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
 import YouTubeRecommender, {
   parseSubscriptions,
   parseHtmlSubscriptions,
@@ -72,6 +75,18 @@ test('parseHtmlSubscriptions ignores items without channel link', () => {
 
 test('parseHtmlSubscriptions returns empty array when no matches', () => {
   expect(parseHtmlSubscriptions('<div></div>')).toEqual([]);
+});
+
+test('parseHtmlSubscriptions handles sample subscriptions html file', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const html = readFileSync(
+    path.join(__dirname, 'fixtures', 'subscriptions.html'),
+    'utf8'
+  );
+  expect(parseHtmlSubscriptions(html)).toEqual([
+    'https://www.youtube.com/@alpha',
+    'https://www.youtube.com/@beta',
+  ]);
 });
 
 test('parseSubscriptions trims whitespace and ignores blanks', () => {

--- a/gpt_reco_app/src/__tests__/fixtures/subscriptions.html
+++ b/gpt_reco_app/src/__tests__/fixtures/subscriptions.html
@@ -1,0 +1,14 @@
+<ytd-item-section-renderer>
+  <ytd-channel-renderer>
+    <ytd-channel-name>
+      <yt-formatted-string id="text">Alpha</yt-formatted-string>
+    </ytd-channel-name>
+    <a class="channel-link" href="/@alpha"></a>
+  </ytd-channel-renderer>
+  <ytd-channel-renderer>
+    <ytd-channel-name>
+      <yt-formatted-string id="text">Beta</yt-formatted-string>
+    </ytd-channel-name>
+    <a class="channel-link" href="https://www.youtube.com/@beta"></a>
+  </ytd-channel-renderer>
+</ytd-item-section-renderer>


### PR DESCRIPTION
## Summary
- add integration test ensuring `/extract-youtube` route renders correctly

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684717e34a40832090e9a42e8f2f3028